### PR TITLE
Add django-ilmoitin

### DIFF
--- a/apartment_application_service/apps.py
+++ b/apartment_application_service/apps.py
@@ -1,0 +1,8 @@
+from django.apps import AppConfig
+
+
+class ApartmentApplicationServiceConfig(AppConfig):
+    name = "apartment_application_service"
+
+    def ready(self):
+        import apartment_application_service.notifications  # noqa

--- a/apartment_application_service/consts.py
+++ b/apartment_application_service/consts.py
@@ -1,0 +1,2 @@
+class NotificationType:
+    APPLICATION_CREATED = "application_created"

--- a/apartment_application_service/notifications.py
+++ b/apartment_application_service/notifications.py
@@ -1,0 +1,22 @@
+from django.utils import timezone
+from django.utils.translation import gettext_lazy as _
+from django_ilmoitin.dummy_context import COMMON_CONTEXT, dummy_context
+from django_ilmoitin.registry import notifications
+from unittest.mock import MagicMock
+
+from apartment_application_service.consts import NotificationType
+
+TEMPLATES = [
+    (NotificationType.APPLICATION_CREATED, _("Application created")),
+]
+
+for template in TEMPLATES:
+    notifications.register(template[0], template[1])
+
+dummy_context.update(
+    {
+        COMMON_CONTEXT: {"created_at": timezone.now()},
+        # TODO: pass more appropriate in-memory objects
+        NotificationType.APPLICATION_CREATED: MagicMock(),
+    }
+)

--- a/apartment_application_service/settings.py
+++ b/apartment_application_service/settings.py
@@ -31,6 +31,8 @@ env = environ.Env(
         "@localhost/apartment-application",
     ),
     CACHE_URL=(str, "locmemcache://"),
+    MAILER_EMAIL_BACKEND=(str, "django.core.mail.backends.console.EmailBackend"),
+    DEFAULT_FROM_EMAIL=(str, "apartment_application_service@example.com"),
     MAIL_MAILGUN_KEY=(str, ""),
     MAIL_MAILGUN_DOMAIN=(str, ""),
     MAIL_MAILGUN_API=(str, ""),
@@ -55,6 +57,11 @@ USE_X_FORWARDED_HOST = env.bool("USE_X_FORWARDED_HOST")
 DATABASES = {"default": env.db()}
 
 CACHES = {"default": env.cache()}
+
+if env.str("DEFAULT_FROM_EMAIL"):
+    DEFAULT_FROM_EMAIL = env.str("DEFAULT_FROM_EMAIL")
+if env.str("MAILER_EMAIL_BACKEND"):
+    MAILER_EMAIL_BACKEND = env.str("MAILER_EMAIL_BACKEND")
 
 try:
     version = subprocess.check_output(["git", "rev-parse", "--short", "HEAD"]).strip()
@@ -91,6 +98,10 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "corsheaders",
+    "parler",
+    "anymail",
+    "mailer",
+    "django_ilmoitin",
     # local apps
     "utils",
 ]
@@ -132,6 +143,10 @@ LOGGING = {
     "handlers": {"console": {"class": "logging.StreamHandler"}},
     "loggers": {"django": {"handlers": ["console"], "level": "ERROR"}},
 }
+
+SITE_ID = 1
+
+PARLER_LANGUAGES = {SITE_ID: ({"code": "fi"}, {"code": "en"}, {"code": "sv"})}
 
 # local_settings.py can be used to override environment-specific settings
 # like database and email that differ between development and production.

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,6 @@
 Django~=2.2
 django-cors-headers
 django-environ
+django-ilmoitin~=0.5.0
 psycopg2
 sentry-sdk

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,12 +4,23 @@
 #
 #    pip-compile requirements.in
 #
-certifi==2020.6.20        # via sentry-sdk
+certifi==2020.6.20        # via requests, sentry-sdk
+chardet==3.0.4            # via requests
+django-anymail==7.2.1     # via django-ilmoitin
 django-cors-headers==3.5.0  # via -r requirements.in
 django-environ==0.4.5     # via -r requirements.in
-django==2.2.13            # via -r requirements.in, django-cors-headers
+django-ilmoitin==0.5.3    # via -r requirements.in
+django-mailer==2.0.1      # via django-ilmoitin
+django-parler==1.9.2      # via django-ilmoitin
+django==2.2.13            # via -r requirements.in, django-anymail, django-cors-headers, django-ilmoitin, django-mailer
+idna==2.10                # via requests
+jinja2==2.11.2            # via django-ilmoitin
+lockfile==0.12.2          # via django-mailer
+markupsafe==1.1.1         # via jinja2
 psycopg2==2.8.6           # via -r requirements.in
 pytz==2020.1              # via django
+requests==2.24.0          # via django-anymail
 sentry-sdk==0.17.3        # via -r requirements.in
+six==1.15.0               # via django-anymail, django-mailer
 sqlparse==0.3.1           # via django
-urllib3==1.25.10          # via sentry-sdk
+urllib3==1.25.10          # via requests, sentry-sdk


### PR DESCRIPTION
Add inintial integration of django-ilmoitin 0.5 to the project.
From django-ilmoitin readme: "Use version 0.5.x for a project based
on Django 2.x".

ASU-222 | Integrate django-ilmoitin