### PR TITLE
Update django-etuovi mapper typing test

### DIFF
--- a/connections/tests/test_etuovi_mapper.py
+++ b/connections/tests/test_etuovi_mapper.py
@@ -1,4 +1,4 @@
-import typing
+from django_etuovi.utils.testing import check_dataclass_typing
 
 from connections.etuovi.mapper import map_apartment_to_item
 from connections.tests.factories import ApartmentFactory
@@ -7,8 +7,4 @@ from connections.tests.factories import ApartmentFactory
 def test_apartment_to_item_mapping_types():
     apartment = ApartmentFactory()
     item = map_apartment_to_item(apartment)
-
-    for field_name, field_def in item.__dataclass_fields__.items():
-        actual_type = typing.get_origin(field_def.type) or field_def.type
-        actual_value = getattr(item, field_name)
-        assert isinstance(actual_value, actual_type)
+    check_dataclass_typing(item)


### PR DESCRIPTION
Update the django-etuovi mapper typing test to be imported from the django-etuovi package. This way we don't have to maintain this code in two places.