### PR TITLE
Update dependencies

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,11 +8,11 @@ appdirs==1.4.4
     # via
     #   black
     #   virtualenv
-attrs==20.2.0
+attrs==20.3.0
     # via pytest
 backcall==0.2.0
     # via ipython
-black==20.8b1
+black==21.4b2
     # via -r requirements-dev.in
 cfgv==3.2.0
     # via pre-commit
@@ -20,45 +20,45 @@ click==7.1.2
     # via
     #   black
     #   pip-tools
-coverage==5.2.1
+coverage==5.5
     # via pytest-cov
-decorator==4.4.2
+decorator==5.0.7
     # via ipython
 distlib==0.3.1
     # via virtualenv
-factory-boy==3.0.1
+factory-boy==3.2.0
     # via -r requirements-dev.in
-faker==4.1.3
+faker==8.1.2
     # via factory-boy
 filelock==3.0.12
     # via virtualenv
-flake8==3.8.3
+flake8==3.9.1
     # via -r requirements-dev.in
-identify==2.2.0
+identify==2.2.4
     # via pre-commit
-iniconfig==1.0.1
+iniconfig==1.1.1
     # via pytest
 ipython-genutils==0.2.0
     # via traitlets
-ipython==7.18.1
+ipython==7.23.0
     # via -r requirements-dev.in
-isort==5.5.1
+isort==5.8.0
     # via -r requirements-dev.in
-jedi==0.17.2
+jedi==0.18.0
+    # via ipython
+matplotlib-inline==0.1.2
     # via ipython
 mccabe==0.6.1
     # via flake8
-more-itertools==8.5.0
-    # via pytest
 mypy-extensions==0.4.3
     # via black
-nodeenv==1.5.0
+nodeenv==1.6.0
     # via pre-commit
-packaging==20.4
+packaging==20.9
     # via pytest
-parso==0.7.1
+parso==0.8.2
     # via jedi
-pathspec==0.8.0
+pathspec==0.8.1
     # via black
 pep517==0.10.0
     # via pip-tools
@@ -66,31 +66,31 @@ pexpect==4.8.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-pip-tools==6.0.1
+pip-tools==6.1.0
     # via -r requirements-dev.in
 pluggy==0.13.1
     # via pytest
-pre-commit==2.11.1
+pre-commit==2.12.1
     # via -r requirements-dev.in
-prompt-toolkit==3.0.7
+prompt-toolkit==3.0.18
     # via ipython
-ptyprocess==0.6.0
+ptyprocess==0.7.0
     # via pexpect
 py==1.10.0
     # via pytest
-pycodestyle==2.6.0
+pycodestyle==2.7.0
     # via flake8
-pyflakes==2.2.0
+pyflakes==2.3.1
     # via flake8
-pygments==2.7.4
+pygments==2.9.0
     # via ipython
 pyparsing==2.4.7
     # via packaging
-pytest-cov==2.10.1
+pytest-cov==2.11.1
     # via -r requirements-dev.in
-pytest-django==3.9.0
+pytest-django==4.2.0
     # via -r requirements-dev.in
-pytest==6.0.1
+pytest==6.2.3
     # via
     #   -r requirements-dev.in
     #   pytest-cov
@@ -99,28 +99,25 @@ python-dateutil==2.8.1
     # via faker
 pyyaml==5.4.1
     # via pre-commit
-regex==2020.7.14
+regex==2021.4.4
     # via black
 six==1.15.0
     # via
-    #   packaging
     #   python-dateutil
     #   virtualenv
 text-unidecode==1.3
     # via faker
-toml==0.10.1
+toml==0.10.2
     # via
     #   black
     #   pep517
     #   pre-commit
     #   pytest
-traitlets==5.0.3
-    # via ipython
-typed-ast==1.4.1
-    # via black
-typing-extensions==3.7.4.3
-    # via black
-virtualenv==20.4.3
+traitlets==5.0.5
+    # via
+    #   ipython
+    #   matplotlib-inline
+virtualenv==20.4.4
     # via pre-commit
 wcwidth==0.2.5
     # via prompt-toolkit

--- a/requirements.in
+++ b/requirements.in
@@ -3,10 +3,12 @@ django-cors-headers
 django-environ
 git+git://github.com/City-of-Helsinki/django-etuovi@develop#egg=django_etuovi  # TODO: change this when released in PyPI
 git+git://github.com/City-of-Helsinki/django-oikotie@develop#egg=django_oikotie  # TODO: change this when released in PyPI
-django-helusers
+django-helusers<0.6.0  # TODO: update to version >=0.6.0
 django-ilmoitin~=0.5.0
 django-simple-history
 djangorestframework
+drf-oidc-auth
+elasticsearch~=7.10.1  # TODO: update to version 7.12
 elasticsearch-dsl>=7.0.0,<8.0.0
 psycopg2
 sentry-sdk

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,24 +4,29 @@
 #
 #    pip-compile requirements.in
 #
-certifi==2020.6.20
+authlib==0.15.3
+    # via drf-oidc-auth
+certifi==2020.12.5
     # via
     #   elasticsearch
     #   requests
     #   sentry-sdk
-cffi==1.14.3
+cffi==1.14.5
     # via cryptography
-chardet==3.0.4
+chardet==4.0.0
     # via requests
-cryptography==3.3.2
-    # via social-auth-core
-defusedxml==0.6.0
+cryptography==3.4.7
+    # via
+    #   authlib
+    #   drf-oidc-auth
+    #   social-auth-core
+defusedxml==0.7.1
     # via
     #   python3-openid
     #   social-auth-core
-django-anymail==8.1
+django-anymail==8.2
     # via django-ilmoitin
-django-cors-headers==3.5.0
+django-cors-headers==3.7.0
     # via -r requirements.in
 django-environ==0.4.5
     # via -r requirements.in
@@ -29,13 +34,13 @@ django-helusers==0.5.6
     # via -r requirements.in
 django-ilmoitin==0.5.3
     # via -r requirements.in
-django-mailer==2.0.1
+django-mailer==2.1
     # via django-ilmoitin
 django-parler==1.9.2
     # via django-ilmoitin
-django-simple-history==2.12.0
+django-simple-history==3.0.0
     # via -r requirements.in
-django==2.2.20
+django==2.2.21
     # via
     #   -r requirements.in
     #   django-anymail
@@ -51,20 +56,20 @@ git+git://github.com/City-of-Helsinki/django-etuovi@develop#egg=django_etuovi
     # via -r requirements.in
 git+git://github.com/City-of-Helsinki/django-oikotie@develop#egg=django_oikotie
     # via -r requirements.in
-djangorestframework==3.12.1
+djangorestframework==3.12.4
     # via
     #   -r requirements.in
     #   drf-oidc-auth
-drf-oidc-auth==0.10.0
-    # via django-helusers
+drf-oidc-auth==2.0.0
+    # via
+    #   -r requirements.in
+    #   django-helusers
 ecdsa==0.14.1
     # via python-jose
 elasticsearch-dsl==7.3.0
     # via -r requirements.in
-elasticsearch==7.9.1
+elasticsearch==7.10.1
     # via elasticsearch-dsl
-future==0.18.2
-    # via pyjwkest
 idna==2.10
     # via requests
 jinja2==2.11.3
@@ -89,11 +94,7 @@ pyasn1==0.4.8
     #   rsa
 pycparser==2.20
     # via cffi
-pycryptodomex==3.9.8
-    # via pyjwkest
-pyjwkest==1.4.2
-    # via drf-oidc-auth
-pyjwt==1.7.1
+pyjwt==2.1.0
     # via social-auth-core
 python-dateutil==2.8.1
     # via elasticsearch-dsl
@@ -101,40 +102,36 @@ python-jose==3.2.0
     # via django-helusers
 python3-openid==3.2.0
     # via social-auth-core
-pytz==2020.1
+pytz==2021.1
     # via django
 requests-oauthlib==1.3.0
     # via social-auth-core
-requests==2.24.0
+requests==2.25.1
     # via
     #   django-anymail
     #   django-helusers
-    #   pyjwkest
+    #   drf-oidc-auth
     #   requests-oauthlib
     #   social-auth-core
-rsa==4.6
+rsa==4.7.2
     # via python-jose
-sentry-sdk==0.19.0
+sentry-sdk==1.0.0
     # via -r requirements.in
 six==1.15.0
     # via
-    #   cryptography
     #   django-mailer
-    #   django-simple-history
     #   ecdsa
     #   elasticsearch-dsl
-    #   pyjwkest
     #   python-dateutil
     #   python-jose
     #   social-auth-app-django
-    #   social-auth-core
 social-auth-app-django==4.0.0
     # via -r requirements.in
-social-auth-core==3.3.3
+social-auth-core==4.1.0
     # via social-auth-app-django
 sqlparse==0.4.1
     # via django
-urllib3==1.25.10
+urllib3==1.26.4
     # via
     #   elasticsearch
     #   requests

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,6 @@ combine_as_imports=false
 indent=4
 length_sort=false
 multi_line_output=3
-not_skip=__init__.py
 order_by_type=false
 skip=migrations,venv
 include_trailing_comma = True


### PR DESCRIPTION
Dependabot alert could not create PR because of outdated dependencies.
Used pip-compile --upgrade on all requirements files.

Set elasticsearch library to use version 7.10.1 as greater versions
break tests. At least elasticsearch test client is not starting. Need
to be addressed in near future.

Set django-heluser library to use version less then 0.6 until it is
actual as version bump brakes build.

Include drf-oidc-auth in requirements as django-heluser required this
dependency:
https://github.com/City-of-Helsinki/django-helusers#optional-features.