### PR TITLE
Revert logging settings

### DIFF
--- a/apartment_application_service/settings.py
+++ b/apartment_application_service/settings.py
@@ -38,7 +38,7 @@ env = environ.Env(
     MAIL_MAILGUN_API=(str, ""),
     SENTRY_DSN=(str, ""),
     SENTRY_ENVIRONMENT=(str, ""),
-    LOG_LEVEL=(str, ""),
+    LOG_LEVEL=(str, "ERROR"),
     CORS_ORIGIN_WHITELIST=(list, []),
     CORS_ORIGIN_ALLOW_ALL=(bool, False),
     OIDC_AUDIENCE=(str, ""),
@@ -173,35 +173,8 @@ CORS_ORIGIN_ALLOW_ALL = env.bool("CORS_ORIGIN_ALLOW_ALL")
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
-    "formatters": {
-        "standard": {
-            "format": "%(asctime)s p%(process)d %(name)s %(levelname)s: %(message)s",
-            "datefmt": "%Y-%m-%dT%H:%M:%S.%03dZ",
-        }
-    },
-    "handlers": {
-        "console": {
-            "level": "INFO",
-            "class": "logging.StreamHandler",
-            "formatter": "standard",
-        }
-    },
-    "loggers": {
-        "": {
-            "level": "WARNING",
-            "handlers": [
-                "console",
-            ],
-        },
-        "connections": {
-            "level": env("LOG_LEVEL"),
-            "handlers": [
-                "console",
-            ],
-            # required to avoid double logging with root logger
-            "propagate": False,
-        },
-    },
+    "handlers": {"console": {"class": "logging.StreamHandler"}},
+    "loggers": {"django": {"handlers": ["console"], "level": env.str("LOG_LEVEL")}},
 }
 
 SITE_ID = 1


### PR DESCRIPTION
Currently, there isn't a need to separate logging configurations per app
so previous configurations were reverted. The LOG_LEVEL environment
variable has been left that there is a possibility to manage the logging
level in the console.