### PR TITLE
ASU-712 Add OpenAPI specification and API documentation

### DIFF
--- a/apartment_application_service/openapi.py
+++ b/apartment_application_service/openapi.py
@@ -1,0 +1,54 @@
+from drf_spectacular import openapi
+from typing import List, Optional
+
+
+class AutoSchema(openapi.AutoSchema):
+    def get_tags(self) -> List[str]:
+        """Use verbose names instead of URL path components as tags."""
+        try:
+            return [self._verbose_name_plural.capitalize()]
+        except AttributeError:
+            return super().get_tags()
+
+    def get_summary(self) -> Optional[str]:
+        """
+        Give some sensible default summaries for each type of endpoint.
+        These can be overridden with e.g. @extend_schema_view if needed.
+        """
+        default_summaries = {
+            "create": f"Create {self._verbose_name}",
+            "list": f"Get list of {self._verbose_name_plural}",
+            "retrieve": f"Get {self._verbose_name}",
+            "update": f"Update {self._verbose_name}",
+            "partial_update": f"Patch {self._verbose_name}",
+            "destroy": f"Delete {self._verbose_name}",
+        }
+        return default_summaries.get(self.view.action, super().get_summary())
+
+    def get_description(self) -> str:
+        """
+        Give some sensible default descriptions for each type of endpoint.
+        These can be overridden with e.g. @extend_schema_view if needed.
+        """
+        default_descriptions = {
+            "create": f"Create a new {self._verbose_name} instance with the given details.",  # noqa: E501
+            "list": f"Return a list of all accessible {self._verbose_name_plural}.",
+            "retrieve": f"Return the details of the given {self._verbose_name} instance.",  # noqa: E501
+            "update": f"Update the given {self._verbose_name} with new details.",
+            "partial_update": f"Partially update the given {self._verbose_name} with new details.",  # noqa: E501
+            "destroy": f"Delete the given {self._verbose_name} instance.",
+        }
+        return default_descriptions.get(self.view.action, super().get_description())
+
+    @property
+    def _model_meta(self):
+        # noinspection PyProtectedMember
+        return self.view.serializer_class.Meta.model._meta
+
+    @property
+    def _verbose_name(self):
+        return self._model_meta.verbose_name
+
+    @property
+    def _verbose_name_plural(self):
+        return self._model_meta.verbose_name_plural

--- a/apartment_application_service/settings.py
+++ b/apartment_application_service/settings.py
@@ -132,6 +132,7 @@ INSTALLED_APPS = [
     "social_django",
     "rest_framework",
     "simple_history",
+    "drf_spectacular",
     # local apps
     "application_form",
     "connections",
@@ -200,6 +201,15 @@ REST_FRAMEWORK = {
         "helusers.oidc.ApiTokenAuthentication",
         "rest_framework.authentication.SessionAuthentication",
     ),
+    "DEFAULT_SCHEMA_CLASS": "apartment_application_service.openapi.AutoSchema",
+}
+
+SPECTACULAR_SETTINGS = {
+    "TITLE": "Apartment Application API",
+    "DESCRIPTION": "Apartment application service for the City of Helsinki.",
+    "VERSION": None,
+    "SCHEMA_PATH_PREFIX": r"/v[0-9]+",
+    "SERVE_INCLUDE_SCHEMA": False,
 }
 
 OIDC_API_TOKEN_AUTH = {

--- a/apartment_application_service/urls.py
+++ b/apartment_application_service/urls.py
@@ -1,4 +1,9 @@
 from django.urls import include, path
+from drf_spectacular.views import (
+    SpectacularAPIView,
+    SpectacularRedocView,
+    SpectacularSwaggerView,
+)
 from helusers.admin_site import admin
 
 from application_form import urls as api_urls
@@ -10,4 +15,11 @@ urlpatterns = [
     path("v1/", include((rpc_api_urls, "connections"), namespace="v1/connections")),
     path("", include("social_django.urls", namespace="social")),
     path("helauth/", include("helusers.urls")),
+    path("openapi/", SpectacularAPIView.as_view(), name="schema"),
+    path("api_docs/", SpectacularRedocView.as_view(url_name="schema"), name="redoc"),
+    path(
+        "api_docs/swagger/",
+        SpectacularSwaggerView.as_view(url_name="schema"),
+        name="swagger-ui",
+    ),
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ appdirs==1.4.4
     # via
     #   black
     #   virtualenv
-attrs==20.3.0
+attrs==21.2.0
     # via pytest
 backcall==0.2.0
     # via ipython

--- a/requirements.in
+++ b/requirements.in
@@ -8,6 +8,7 @@ django-ilmoitin~=0.5.0
 django-simple-history
 djangorestframework
 drf-oidc-auth
+drf-spectacular
 elasticsearch~=7.10.1  # TODO: update to version 7.12
 elasticsearch-dsl>=7.0.0,<8.0.0
 psycopg2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,8 @@
 #
 #    pip-compile requirements.in
 #
+attrs==21.2.0
+    # via jsonschema
 authlib==0.15.3
     # via drf-oidc-auth
 certifi==2020.12.5
@@ -52,6 +54,7 @@ django==2.2.21
     #   django-oikotie
     #   djangorestframework
     #   drf-oidc-auth
+    #   drf-spectacular
 git+git://github.com/City-of-Helsinki/django-etuovi@develop#egg=django_etuovi
     # via -r requirements.in
 git+git://github.com/City-of-Helsinki/django-oikotie@develop#egg=django_oikotie
@@ -60,20 +63,29 @@ djangorestframework==3.12.4
     # via
     #   -r requirements.in
     #   drf-oidc-auth
+    #   drf-spectacular
 drf-oidc-auth==2.0.0
     # via
     #   -r requirements.in
     #   django-helusers
+drf-spectacular==0.16.0
+    # via -r requirements.in
 ecdsa==0.14.1
     # via python-jose
 elasticsearch-dsl==7.3.0
     # via -r requirements.in
 elasticsearch==7.10.1
-    # via elasticsearch-dsl
+    # via
+    #   -r requirements.in
+    #   elasticsearch-dsl
 idna==2.10
     # via requests
+inflection==0.5.1
+    # via drf-spectacular
 jinja2==2.11.3
     # via django-ilmoitin
+jsonschema==3.2.0
+    # via drf-spectacular
 lockfile==0.12.2
     # via django-mailer
 lxml==4.6.3
@@ -96,6 +108,8 @@ pycparser==2.20
     # via cffi
 pyjwt==2.1.0
     # via social-auth-core
+pyrsistent==0.17.3
+    # via jsonschema
 python-dateutil==2.8.1
     # via elasticsearch-dsl
 python-jose==3.2.0
@@ -104,6 +118,8 @@ python3-openid==3.2.0
     # via social-auth-core
 pytz==2021.1
     # via django
+pyyaml==5.4.1
+    # via drf-spectacular
 requests-oauthlib==1.3.0
     # via social-auth-core
 requests==2.25.1
@@ -122,6 +138,7 @@ six==1.15.0
     #   django-mailer
     #   ecdsa
     #   elasticsearch-dsl
+    #   jsonschema
     #   python-dateutil
     #   python-jose
     #   social-auth-app-django
@@ -131,8 +148,13 @@ social-auth-core==4.1.0
     # via social-auth-app-django
 sqlparse==0.4.1
     # via django
+uritemplate==3.0.1
+    # via drf-spectacular
 urllib3==1.26.4
     # via
     #   elasticsearch
     #   requests
     #   sentry-sdk
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools


### PR DESCRIPTION
This PR adds an [OpenAPI specification](https://swagger.io/specification/) and API documentation generation to the project, as recommended by [the documentation best practices](https://dev.hel.fi/documentation#api-documentation).

The OpenAPI spec is served at the `/openapi/` endpoint.

The API documentation can be viewed at:
* `/api_docs/` for Redoc UI
* `/api_docs/swagger/` for Swagger UI

See [ASU-712](https://helsinkisolutionoffice.atlassian.net/browse/ASU-712) for screenshots of the generated documentation.

The API spec and documentation are automatically generated by [drf-spectacular](https://github.com/tfranzel/drf-spectacular). By default, it does not generate very human-readable endpoint summaries and descriptions, so its `AutoSchema` has been extended to provide a bit more readable texts by default. They can all be overridden by views, using [`@extend_schema_view` or similar](https://drf-spectacular.readthedocs.io/en/latest/customization.html) from drf-spectacular.