### PR TITLE
Fix VAR_ROOT error when treated as a path

### DIFF
--- a/apartment_application_service/settings.py
+++ b/apartment_application_service/settings.py
@@ -11,10 +11,10 @@ assert os.path.exists(checkout_dir("manage.py"))
 parent_dir = checkout_dir.path("..")
 if os.path.isdir(parent_dir("etc")):
     env_file = parent_dir("etc/env")
-    default_var_root = environ.Path(parent_dir("var"))
+    default_var_root = parent_dir("var")
 else:
     env_file = checkout_dir(".env")
-    default_var_root = environ.Path(checkout_dir("var"))
+    default_var_root = checkout_dir("var")
 
 env = environ.Env(
     DEBUG=(bool, False),


### PR DESCRIPTION
Using `environ.Path` with `default_var_root` seemed to cause local Docker builds to fail with an error:

```
Traceback (most recent call last):
  File "manage.py", line 23, in <module>
    main()
  File "manage.py", line 19, in main
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python3.8/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python3.8/site-packages/django/core/management/__init__.py", line 325, in execute
    settings.INSTALLED_APPS
  File "/usr/local/lib/python3.8/site-packages/django/conf/__init__.py", line 79, in __getattr__
    self._setup(name)
  File "/usr/local/lib/python3.8/site-packages/django/conf/__init__.py", line 66, in _setup
    self._wrapped = Settings(settings_module)
  File "/usr/local/lib/python3.8/site-packages/django/conf/__init__.py", line 157, in __init__
    mod = importlib.import_module(self.SETTINGS_MODULE)
  File "/usr/local/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 783, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/app/apartment_application_service/settings.py", line 103, in <module>
    var_root = env.path("VAR_ROOT")
  File "/usr/local/lib/python3.8/site-packages/environ/environ.py", line 234, in path
    return Path(self.get_value(var, default=default), **kwargs)
  File "/usr/local/lib/python3.8/site-packages/environ/environ.py", line 289, in get_value
    if value != default or (parse_default and value):
  File "/usr/local/lib/python3.8/site-packages/environ/environ.py", line 733, in __ne__
    return not self.__eq__(other)
  File "/usr/local/lib/python3.8/site-packages/environ/environ.py", line 730, in __eq__
    return self.__root__ == other.__root__
AttributeError: 'str' object has no attribute '__root__'
```

This happens for example when running:

    docker build . --target staticbuilder

The problem is `VAR_ROOT` is passed as an ENV string in `Dockerfile`, while the Django settings expected it to be a path.

The error disappears if we don't convert the variable to a path.