### PR TITLE
ASU-793 Add whitenoise for OpenShift enviroments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ coverage.xml
 local_settings.py
 db.sqlite3
 db.sqlite3-journal
+static/
 
 # Flask stuff:
 instance/

--- a/apartment_application_service/settings.py
+++ b/apartment_application_service/settings.py
@@ -108,6 +108,7 @@ MEDIA_ROOT = var_root("media")
 STATIC_ROOT = var_root("static")
 MEDIA_URL = env.str("MEDIA_URL")
 STATIC_URL = env.str("STATIC_URL")
+STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 
 ROOT_URLCONF = "apartment_application_service.urls"
 WSGI_APPLICATION = "apartment_application_service.wsgi.application"
@@ -144,6 +145,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "corsheaders.middleware.CorsMiddleware",
     "django.middleware.locale.LocaleMiddleware",

--- a/requirements.in
+++ b/requirements.in
@@ -14,3 +14,4 @@ elasticsearch-dsl>=7.0.0,<8.0.0
 psycopg2
 sentry-sdk
 social-auth-app-django
+whitenoise

--- a/requirements.txt
+++ b/requirements.txt
@@ -155,6 +155,8 @@ urllib3==1.26.4
     #   elasticsearch
     #   requests
     #   sentry-sdk
+whitenoise==5.2.0
+    # via -r requirements.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
With a couple of lines of config WhiteNoise allows your web app to serve
its own static files, making it a self-contained unit that can be
deployed anywhere without relying on nginx, Amazon S3 or any other
external service. (Especially useful on Heroku, OpenShift and other PaaS
providers.)

Refs ASU-793