### PR TITLE
ASU-818 Add audit logging for user profile operations

### DIFF
--- a/audit_log/enums.py
+++ b/audit_log/enums.py
@@ -10,7 +10,9 @@ class Operation(Enum):
 
 class Role(Enum):
     OWNER = "OWNER"
+    USER = "USER"
     SYSTEM = "SYSTEM"
+    ANONYMOUS = "ANONYMOUS"
 
 
 class Status(Enum):

--- a/audit_log/tests/conftest.py
+++ b/audit_log/tests/conftest.py
@@ -12,5 +12,10 @@ def profile() -> Profile:
 
 
 @fixture
+def other_profile() -> Profile:
+    return ProfileFactory(id="f5cf186a-f9a8-4671-a7a5-1ecbe758071f")
+
+
+@fixture
 def fixed_datetime() -> Callable[[], datetime]:
     return lambda: datetime(2020, 6, 1, tzinfo=timezone.utc)

--- a/users/api/permissions.py
+++ b/users/api/permissions.py
@@ -4,3 +4,6 @@ from rest_framework.permissions import IsAuthenticated
 class IsCreatingOrAuthenticated(IsAuthenticated):
     def has_permission(self, request, view):
         return view.action == "create" or super().has_permission(request, view)
+
+    def has_object_permission(self, request, view, obj):
+        return obj.user == request.user

--- a/users/api/views.py
+++ b/users/api/views.py
@@ -41,8 +41,7 @@ class ProfileViewSet(
         # Unauthenticated users cannot access any profile
         if self.request.user.is_anonymous:
             return self.queryset.none()
-        # Authenticated users should only have access to their own profile
-        return self.queryset.filter(user=self.request.user)
+        return self.queryset
 
     def get_object(self):
         masked_profile_id = self.kwargs[self.lookup_field]

--- a/users/api/views.py
+++ b/users/api/views.py
@@ -1,10 +1,18 @@
+from copy import copy
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
+from django.db.models import Model
 from drf_spectacular.utils import extend_schema, extend_schema_view, OpenApiParameter
 from rest_framework import mixins, status
+from rest_framework.exceptions import NotAuthenticated, PermissionDenied
+from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
+from typing import Optional, Union
 
+from audit_log import audit_logging
+from audit_log.enums import Operation, Status
 from users.api.permissions import IsCreatingOrAuthenticated
 from users.api.serializers import MaskedTokenObtainPairSerializer, ProfileSerializer
 from users.masking import mask_string, mask_uuid, unmask_uuid
@@ -36,17 +44,34 @@ class ProfileViewSet(
     serializer_class = ProfileSerializer
     permission_classes = [IsCreatingOrAuthenticated]
     http_method_names = ["get", "post", "put", "delete"]
+    method_to_operation = {
+        "POST": Operation.CREATE,
+        "GET": Operation.READ,
+        "PUT": Operation.UPDATE,
+        "DELETE": Operation.DELETE,
+    }
 
-    def get_queryset(self):
-        # Unauthenticated users cannot access any profile
-        if self.request.user.is_anonymous:
-            return self.queryset.none()
-        return self.queryset
+    def permission_denied(self, request, message=None, code=None):
+        try:
+            super().permission_denied(request, message, code)
+        except (NotAuthenticated, PermissionDenied):
+            actor = self._get_actor(request)
+            operation = self.method_to_operation[request.method]
+            target = self._get_target(request)
+            audit_logging.log(actor, operation, target, Status.FORBIDDEN)
+            raise
 
-    def get_object(self):
-        masked_profile_id = self.kwargs[self.lookup_field]
-        self.kwargs[self.lookup_field] = unmask_uuid(masked_profile_id)
-        return super().get_object()
+    def initial(self, request, *args, **kwargs):
+        if self.lookup_field in self.kwargs:
+            self.kwargs[self.lookup_field] = unmask_uuid(self.kwargs[self.lookup_field])
+        super().initial(request, *args, **kwargs)
+
+    def retrieve(self, request, *args, **kwargs):
+        response = super(ProfileViewSet, self).retrieve(request, *args, **kwargs)
+        actor = self._get_actor(request)
+        target = self.get_object()
+        audit_logging.log(actor, Operation.READ, target)
+        return response
 
     def create(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data)
@@ -54,6 +79,29 @@ class ProfileViewSet(
         self.perform_create(serializer)
         credentials = self._create_credentials(serializer.instance.user)
         return Response(credentials, status=status.HTTP_201_CREATED)
+
+    def perform_create(self, serializer):
+        super().perform_create(serializer)
+        audit_logging.log(
+            self._get_actor(self.request),
+            Operation.CREATE,
+            serializer.instance,
+        )
+
+    def perform_update(self, serializer):
+        super().perform_update(serializer)
+        audit_logging.log(
+            self._get_actor(self.request),
+            Operation.UPDATE,
+            serializer.instance,
+        )
+
+    def perform_destroy(self, instance):
+        # Actor or target (or both) may be gone after super().perform_destroy
+        actor = copy(self._get_actor(self.request))
+        target = copy(instance)
+        super().perform_destroy(instance)
+        audit_logging.log(actor, Operation.DELETE, target)
 
     def _create_credentials(self, user) -> dict:
         password = get_user_model().objects.make_random_password(length=32)
@@ -65,6 +113,13 @@ class ProfileViewSet(
             ),
             MaskedTokenObtainPairSerializer.password_field: mask_string(password),
         }
+
+    def _get_actor(self, request: Request) -> Union[Profile, AnonymousUser]:
+        return getattr(request.user, "profile", request.user)
+
+    def _get_target(self, request: Request) -> Optional[Model]:
+        profile_uuid = self.kwargs.get(self.lookup_field, None)
+        return Profile.objects.filter(pk=profile_uuid).first()
 
 
 @extend_schema_view(

--- a/users/tests/test_api.py
+++ b/users/tests/test_api.py
@@ -42,7 +42,7 @@ def test_profile_get_detail_fails_if_not_own_profile(
     response = api_client.get(
         reverse("users:profile-detail", args=(mask_uuid(other_profile.pk),))
     )
-    assert response.status_code == 404
+    assert response.status_code == 403
 
 
 @pytest.mark.django_db
@@ -105,7 +105,7 @@ def test_profile_put_fails_if_not_own_profile(profile, other_profile, api_client
         "street_address": "Kauppakatu 23",
     }
     response = api_client.put(url, put_data)
-    assert response.status_code == 404
+    assert response.status_code == 403
 
 
 @pytest.mark.django_db
@@ -156,7 +156,7 @@ def test_profile_delete_fails_if_not_own_profile(profile, other_profile, api_cli
     api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {_create_token(profile)}")
     url = reverse("users:profile-detail", args=(mask_uuid(other_profile.pk),))
     response = api_client.delete(url)
-    assert response.status_code == 404
+    assert response.status_code == 403
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
This PR adds audit logging for all CRUD operations for user profiles.

Each audit log entry has an *actor*, *operation*, and *target*.

* The actor is the authenticated user profile.
  * The only exception to this is creating a new profile -- since no user can be authenticated before the profile is created, the user is anonymous.
* The action is either `CREATE`, `READ`, `UPDATE`, or `DELETE` depending on the HTTP method.
* The target is the user profile.