### PR TITLE
Add abstract timestamped model

### DIFF
--- a/apartment_application_service/models.py
+++ b/apartment_application_service/models.py
@@ -1,0 +1,9 @@
+from django.db import models
+
+
+class TimestampedModel(models.Model):
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        abstract = True

--- a/application_form/models.py
+++ b/application_form/models.py
@@ -4,11 +4,12 @@ from enumfields import EnumField
 from uuid import uuid4
 
 from apartment.models import Apartment
+from apartment_application_service.models import TimestampedModel
 from application_form.enums import ApplicationType
 from users.models import Profile
 
 
-class Application(models.Model):
+class Application(TimestampedModel):
     external_uuid = models.UUIDField(
         _("application identifier"), default=uuid4, editable=False
     )
@@ -16,8 +17,6 @@ class Application(models.Model):
     type = EnumField(ApplicationType, max_length=15, verbose_name=_("application type"))
     right_of_residence = models.CharField(_("right of residence number"), max_length=10)
     has_children = models.BooleanField(_("has children"), default=False)
-    created_at = models.DateTimeField(auto_now_add=True)
-    updated_at = models.DateTimeField(auto_now=True)
     profile = models.ForeignKey(Profile, on_delete=models.CASCADE)
     apartments = models.ManyToManyField(
         Apartment,
@@ -26,7 +25,7 @@ class Application(models.Model):
     )
 
 
-class Applicant(models.Model):
+class Applicant(TimestampedModel):
     first_name = models.CharField(_("first name"), max_length=30)
     last_name = models.CharField(_("last name"), max_length=150)
     email = models.EmailField(_("email"))
@@ -42,8 +41,6 @@ class Applicant(models.Model):
         null=True,
     )
     is_primary_applicant = models.BooleanField(_("is primary applicant"), default=False)
-    created_at = models.DateTimeField(auto_now_add=True)
-    updated_at = models.DateTimeField(auto_now=True)
     application = models.ForeignKey(
         Application, on_delete=models.CASCADE, related_name="applicants"
     )

--- a/users/models.py
+++ b/users/models.py
@@ -5,6 +5,8 @@ from django.utils.translation import ugettext_lazy as _
 from helusers.models import AbstractUser
 from uuid import uuid4
 
+from apartment_application_service.models import TimestampedModel
+
 _logger = logging.getLogger(__name__)
 
 
@@ -14,7 +16,7 @@ class User(AbstractUser):
         verbose_name_plural = _("users")
 
 
-class Profile(models.Model):
+class Profile(TimestampedModel):
     CONTACT_LANGUAGE_CHOICES = [
         ("fi", _("Finnish")),
         ("sv", _("Swedish")),
@@ -38,8 +40,6 @@ class Profile(models.Model):
         max_length=2,
         choices=CONTACT_LANGUAGE_CHOICES,
     )
-    created_at = models.DateTimeField(auto_now_add=True)
-    updated_at = models.DateTimeField(auto_now=True)
 
     def delete(self, *args, **kwargs):
         pk = self.pk


### PR DESCRIPTION
This PR adds an abstract `TimestampedModel` that provides `created_at` and `updated_at` fields.

The models that have these fields have been updated to inherit from this class.

No migrations are needed since the affected models already included these fields.