### PR TITLE
ASU-859 Add option to choose vendor for transfer

### DIFF
--- a/connections/etuovi/services.py
+++ b/connections/etuovi/services.py
@@ -19,6 +19,7 @@ def fetch_apartments_for_sale() -> list:
         Search()
         .query("match", _language="fi")
         .query("match", apartment_state_of_sale=ApartmentStateOfSale.FOR_SALE)
+        .query("match", publish_on_etuovi=True)
     )
     s_obj.execute()
     scan = s_obj.scan()

--- a/connections/etuovi/services.py
+++ b/connections/etuovi/services.py
@@ -34,7 +34,7 @@ def fetch_apartments_for_sale() -> list:
         _logger.warning(
             "There were no apartments to map or could not map any apartments"
         )
-    _logger.info(f"Succefully mapped {len(items)} apartments for sale")
+    _logger.info(f"Successfully mapped {len(items)} apartments for sale")
     return items
 
 

--- a/connections/management/commands/send_etuovi_xml_file.py
+++ b/connections/management/commands/send_etuovi_xml_file.py
@@ -34,8 +34,8 @@ class Command(BaseCommand):
             try:
                 send_items(path, xml_file)
                 _logger.info(
-                    f"Succefully sent Etuovi XML file {path}/{xml_file} to Etuovi FTP "
-                    "server"
+                    f"Successfully sent Etuovi XML file {path}/{xml_file} to Etuovi "
+                    "FTP server"
                 )
             except Exception as e:
                 _logger.error(

--- a/connections/oikotie/services.py
+++ b/connections/oikotie/services.py
@@ -22,6 +22,7 @@ def fetch_apartments_for_sale() -> Tuple[list, list]:
         Search()
         .query("match", _language="fi")
         .query("match", apartment_state_of_sale=ApartmentStateOfSale.FOR_SALE)
+        .query("match", publish_on_oikotie=True)
     )
     s_obj.execute()
     scan = s_obj.scan()

--- a/connections/oikotie/services.py
+++ b/connections/oikotie/services.py
@@ -47,7 +47,7 @@ def fetch_apartments_for_sale() -> Tuple[list, list]:
         _logger.warning(
             "There were no apartments to map or could not map any apartments"
         )
-    _logger.info(f"Succefully mapped {len(apartments)} apartments for sale")
+    _logger.info(f"Successfully mapped {len(apartments)} apartments for sale")
     return (apartments, housing_companies)
 
 

--- a/connections/tests/factories.py
+++ b/connections/tests/factories.py
@@ -154,6 +154,8 @@ class ApartmentFactory(factory.Factory):
     additional_information = fuzzy.FuzzyText()
     application_url = fuzzy.FuzzyText()
     image_urls = factory.List([fuzzy.FuzzyText() for _ in range(2)])
+    publish_on_etuovi = Faker("boolean")
+    publish_on_oikotie = Faker("boolean")
 
 
 class ApartmentMinimalFactory(factory.Factory):
@@ -187,21 +189,33 @@ class ApartmentMinimalFactory(factory.Factory):
     room_count = fuzzy.FuzzyInteger(0, 9999999999)
     sales_price = fuzzy.FuzzyInteger(0, 9999999999)
     debt_free_sales_price = fuzzy.FuzzyInteger(0, 9999999999)
-    project_state_of_sale = fuzzy.FuzzyChoice(["PRE_MARKETING", "FOR_SALE", "SOLD"])
-    apartment_state_of_sale = fuzzy.FuzzyChoice(["RESERVED", "FOR_SALE"])
+    project_state_of_sale = fuzzy.FuzzyChoice(ProjectStateOfSale)
+    apartment_state_of_sale = fuzzy.FuzzyChoice(ApartmentStateOfSale)
     project_description = fuzzy.FuzzyText(length=200)
     url = fuzzy.FuzzyText(length=20)
+    publish_on_etuovi = Faker("boolean")
+    publish_on_oikotie = Faker("boolean")
 
     @classmethod
-    def build_for_sale_batch(cls, size: int) -> List[ApartmentTest]:
+    def build_batch_with_flags_published_and_state_of_sale(
+        cls,
+        size: int,
+        for_sale=False,
+        published_on_etuovi=False,
+        published_on_oikotie=False,
+    ) -> List[ApartmentTest]:
+        if for_sale:
+            for_sale = ApartmentStateOfSale.FOR_SALE
+        else:
+            for_sale = ApartmentStateOfSale.RESERVED
         return [
             cls.build(
-                publish_on_etuovi=True,
-                publish_on_oikotie=True,
-                apartment_state_of_sale="FOR_SALE",
+                publish_on_etuovi=published_on_etuovi,
+                publish_on_oikotie=published_on_oikotie,
+                apartment_state_of_sale=for_sale,
                 _language="fi",
             )
-            for _ in range(size)
+            for i in range(size)
         ]
 
     @classmethod

--- a/connections/tests/factories.py
+++ b/connections/tests/factories.py
@@ -203,3 +203,15 @@ class ApartmentMinimalFactory(factory.Factory):
             )
             for _ in range(size)
         ]
+
+    @classmethod
+    def build_for_sale_batch(cls, size: int) -> List[ApartmentTest]:
+        return [
+            cls.build(
+                publish_on_etuovi=True,
+                publish_on_oikotie=True,
+                apartment_state_of_sale="FOR_SALE",
+                _language="fi",
+            )
+            for _ in range(size)
+        ]

--- a/connections/tests/test_api.py
+++ b/connections/tests/test_api.py
@@ -2,8 +2,11 @@ import pytest
 from django.core.management import call_command
 
 from connections.tests.utils import (
-    get_elastic_apartments_for_sale_uuids,
+    get_elastic_apartments_for_sale_only_uuids,
+    get_elastic_apartments_for_sale_published_uuids,
+    get_elastic_apartments_not_for_sale,
     make_apartments_sold_in_elastic,
+    publish_elastic_apartments,
 )
 
 
@@ -12,13 +15,52 @@ from connections.tests.utils import (
 class TestConnectionsApis:
     @pytest.mark.usefixtures("not_sending_oikotie_ftp", "not_sending_etuovi_ftp")
     def test_get_mapped_apartments(self, api_client):
-        expected = get_elastic_apartments_for_sale_uuids()
+        expected = get_elastic_apartments_for_sale_published_uuids()
+
         call_command("send_etuovi_xml_file")
         call_command("send_oikotie_xml_file")
 
         response = api_client.get("/v1/connections/get_mapped_apartments", follow=True)
 
         assert response.data == expected
+
+    @pytest.mark.usefixtures("not_sending_oikotie_ftp", "not_sending_etuovi_ftp")
+    def test_get_new_published_apartments(self, api_client):
+        expected = get_elastic_apartments_for_sale_published_uuids()
+
+        call_command("send_etuovi_xml_file")
+        call_command("send_oikotie_xml_file")
+
+        response = api_client.get("/v1/connections/get_mapped_apartments", follow=True)
+
+        assert sorted(response.data) == sorted(expected)
+
+        not_published = get_elastic_apartments_for_sale_only_uuids()
+        expected_new = publish_elastic_apartments(
+            not_published, publish_to_etuovi=True, publish_to_oikotie=True
+        )
+
+        call_command("send_etuovi_xml_file")
+        call_command("send_oikotie_xml_file")
+
+        response_new = api_client.get(
+            "/v1/connections/get_mapped_apartments", follow=True
+        )
+
+        assert sorted(response_new.data) == sorted(expected_new)
+        # new apartments are 3 from not published anywhere
+        assert len(response_new.data) - len(response.data) == 3
+
+    @pytest.mark.usefixtures("not_sending_oikotie_ftp", "not_sending_etuovi_ftp")
+    def test_apartments_for_sale_need_FOR_SALE_flag(self, api_client):
+        expected = get_elastic_apartments_not_for_sale()
+
+        call_command("send_etuovi_xml_file")
+        call_command("send_oikotie_xml_file")
+
+        response = api_client.get("/v1/connections/get_mapped_apartments", follow=True)
+
+        assert set(expected) not in set(response.data)
 
     @pytest.mark.usefixtures("not_sending_oikotie_ftp", "not_sending_etuovi_ftp")
     def test_no_mapped_apartments(self, api_client):

--- a/connections/tests/utils.py
+++ b/connections/tests/utils.py
@@ -1,36 +1,131 @@
-from elasticsearch_dsl import Search
+from django.conf import settings
+from elasticsearch_dsl import Search, UpdateByQuery
 from time import sleep
 
 from connections.enums import ApartmentStateOfSale
 
 
 def make_apartments_sold_in_elastic() -> None:
-    s_obj = Search(index="test-apartment").query(
+    s_obj = Search(index=settings.APARTMENT_INDEX_NAME).query(
         "match", apartment_state_of_sale=ApartmentStateOfSale.FOR_SALE
     )
     s_obj.delete()
     sleep(3)
 
 
-def get_elastic_apartments_for_sale_uuids() -> list:
+def get_elastic_apartments_for_sale_published_on_etuovi_uuids(
+    only_etuovi_published=False,
+) -> list:
+    """
+    Get apartments for sale and published only on Etuovi
+    If oikotie_published is False exclude apartments published on Oikotie
+    """
     s_obj = (
         Search()
         .query("match", _language="fi")
         .query("match", apartment_state_of_sale=ApartmentStateOfSale.FOR_SALE)
+        .query("match", publish_on_etuovi=True)
+    )
+    if only_etuovi_published:
+        s_obj = s_obj.query("match", publish_on_oikotie=False)
+
+    s_obj.execute()
+    scan = s_obj.scan()
+    uuids = []
+    for hit in scan:
+        uuids.append(hit.uuid)
+    return uuids
+
+
+def get_elastic_apartments_for_sale_published_on_oikotie_uuids(
+    only_oikotie_published=False,
+) -> list:
+    """
+    Get apartments for sale and published on Oikotie
+    If etuovi_published is False exclude apartments published on Etuovi
+    """
+    s_obj = (
+        Search()
+        .query("match", _language="fi")
+        .query("match", apartment_state_of_sale=ApartmentStateOfSale.FOR_SALE)
+        .query("match", publish_on_oikotie=True)
+    )
+    if only_oikotie_published:
+        s_obj = s_obj.query("match", publish_on_etuovi=False)
+
+    s_obj.execute()
+    scan = s_obj.scan()
+    uuids = []
+    for hit in scan:
+        uuids.append(hit.uuid)
+    return uuids
+
+
+def get_elastic_apartments_for_sale_published_uuids() -> list:
+    """
+    Get apartments for sale and published both on Oikotie and Etuovi
+    """
+    s_obj = (
+        Search()
+        .query("match", _language="fi")
+        .query("match", apartment_state_of_sale=ApartmentStateOfSale.FOR_SALE)
+        .query("match", publish_on_etuovi=True)
+        .query("match", publish_on_oikotie=True)
+    )
+
+    s_obj.execute()
+    scan = s_obj.scan()
+    uuids = []
+    for hit in scan:
+        uuids.append(hit.uuid)
+    return uuids
+
+
+def get_elastic_apartments_for_sale_only_uuids() -> list:
+    """
+    Get apartments only for sale but not to published
+    """
+    s_obj = (
+        Search()
+        .query("match", _language="fi")
+        .query("match", apartment_state_of_sale=ApartmentStateOfSale.FOR_SALE)
+        .query("match", publish_on_etuovi=False)
+        .query("match", publish_on_oikotie=False)
+    )
+
+    s_obj.execute()
+    scan = s_obj.scan()
+    uuids = []
+    for hit in scan:
+        uuids.append(hit.uuid)
+    return uuids
+
+
+def get_elastic_apartments_not_for_sale():
+    """
+    Get apartments not for sale but with published flags
+    """
+    s_obj = (
+        Search()
+        .query("match", publish_on_oikotie=True)
+        .query("match", publish_on_etuovi=True)
+        .query("match", apartment_state_of_sale=ApartmentStateOfSale.RESERVED)
     )
     s_obj.execute()
     scan = s_obj.scan()
     uuids = []
     for hit in scan:
-        uuids.append(str(hit.uuid))
+        uuids.append(hit.uuid)
     return uuids
 
 
 def get_elastic_apartments_for_sale_project_uuids() -> list:
+    """Used only in oikotie tests for fetching expected housing companies"""
     s_obj = (
         Search()
         .query("match", _language="fi")
         .query("match", apartment_state_of_sale=ApartmentStateOfSale.FOR_SALE)
+        .query("match", publish_on_oikotie=True)
     )
     s_obj.execute()
     scan = s_obj.scan()
@@ -38,3 +133,57 @@ def get_elastic_apartments_for_sale_project_uuids() -> list:
     for hit in scan:
         uuids.append(str(hit.project_uuid))
     return uuids
+
+
+def publish_elastic_apartments(
+    uuids: list, publish_to_etuovi=False, publish_to_oikotie=False
+) -> list:
+    """
+    Sets flags publish_on_oikotie or/and publish_on_etuovi to true
+    for apartments in elasticsearch provided as list of uuids
+    """
+    u_obj = UpdateByQuery(
+        index=settings.APARTMENT_INDEX_NAME,
+    ).query("multi_match", query=" ".join(uuids), fields=["uuid"])
+
+    if publish_to_etuovi and publish_to_oikotie:
+        u_obj = u_obj.script(
+            source="ctx._source.publish_on_oikotie = true; "
+            "ctx._source.publish_on_etuovi = true"
+        )
+    elif publish_to_oikotie:
+        u_obj = u_obj.script(source="ctx._source.publish_on_oikotie = true")
+    elif publish_to_etuovi:
+        u_obj = u_obj.script(source="ctx._source.publish_on_etuovi = true")
+    u_obj.execute()
+    sleep(3)
+
+    s_obj = (
+        Search()
+        .query("match", _language="fi")
+        .query("match", apartment_state_of_sale=ApartmentStateOfSale.FOR_SALE)
+    )
+    if publish_to_oikotie:
+        s_obj = s_obj.query("match", publish_on_oikotie=publish_to_oikotie)
+    if publish_to_etuovi:
+        s_obj = s_obj.query("match", publish_on_etuovi=publish_to_etuovi)
+    scan = s_obj.scan()
+    uuids = []
+
+    for hit in scan:
+        uuids.append(hit.uuid)
+    return uuids
+
+
+def unpublish_elastic_oikotie_apartments(uuids: list) -> list:
+    """
+    Sets flag publish_on_oikotieto to false for apartments
+    in elasticsearch provided as list of uuids
+    """
+    u_obj = UpdateByQuery(
+        index=settings.APARTMENT_INDEX_NAME,
+    ).query("multi_match", query=" ".join(uuids), fields=["uuid"])
+
+    u_obj = u_obj.script(source="ctx._source.publish_on_oikotie = false")
+    u_obj.execute()
+    sleep(3)


### PR DESCRIPTION
This PR adds option to extract apartments from elastic data by flags published_on_oikotie and published_on_etuovi.

Test data generation for elasticsearch has been modified to better address Oikotie and Etuovi fetching separation. Test utils has been added for different testing purposes. Some improving was done overall for testing utils. 