### PR TITLE
Remove right of residence number from user profile

### DIFF
--- a/users/api/serializers.py
+++ b/users/api/serializers.py
@@ -35,7 +35,6 @@ class ProfileSerializer(ModelSerializer):
             "date_of_birth",
             "city",
             "postal_code",
-            "right_of_residence",
             "contact_language",
         ]
 

--- a/users/models.py
+++ b/users/models.py
@@ -34,7 +34,6 @@ class Profile(TimestampedModel):
     date_of_birth = models.DateField(_("date of birth"))
     city = models.CharField(_("city"), max_length=50)
     postal_code = models.CharField(_("postal code"), max_length=10)
-    right_of_residence = models.CharField(_("right of residence number"), max_length=10)
     contact_language = models.CharField(
         _("contact language"),
         max_length=2,

--- a/users/tests/conftest.py
+++ b/users/tests/conftest.py
@@ -16,7 +16,6 @@ PROFILE_TEST_DATA = {
     "city": "Helsinki",
     "postal_code": "00100",
     "date_of_birth": "1980-01-25",
-    "right_of_residence": "123456789",
     "contact_language": "fi",
 }
 

--- a/users/tests/factories.py
+++ b/users/tests/factories.py
@@ -1,5 +1,4 @@
 import factory
-import string
 from factory import Faker, fuzzy
 
 from users.models import Profile, User
@@ -26,6 +25,5 @@ class ProfileFactory(factory.django.DjangoModelFactory):
     city = Faker("city")
     postal_code = Faker("postcode")
     date_of_birth = Faker("date_of_birth", minimum_age=17, maximum_age=99)
-    right_of_residence = fuzzy.FuzzyText(length=10, chars=string.digits)
     contact_language = fuzzy.FuzzyChoice(list(CONTACT_LANGUAGE_CHOICES))
     user = factory.SubFactory(UserFactory)


### PR DESCRIPTION
This PR removes the right of residence number from the `Profile` model.

The right of residence number will actually be provided in the application form instead, and will not be asked from the user when creating the user account. So the right of residence number will be stored in the `Application` model instead, where [the field already exists](https://github.com/City-of-Helsinki/apartment-application-service/blob/c9b19eac6c91e85b87d0df84fff775a6af4ed0f6/application_form/models.py#L18).