### PR TITLE
ASU-819 Add audit logging for applications

### DIFF
--- a/application_form/api/views.py
+++ b/application_form/api/views.py
@@ -1,11 +1,11 @@
 from rest_framework.permissions import IsAuthenticated
-from rest_framework.viewsets import ModelViewSet
 
 from application_form.api.serializers import ApplicationSerializer
 from application_form.models import Application
+from audit_log.viewsets import AuditLoggingModelViewSet
 
 
-class ApplicationViewSet(ModelViewSet):
+class ApplicationViewSet(AuditLoggingModelViewSet):
     queryset = Application.objects.all()
     serializer_class = ApplicationSerializer
     permission_classes = [IsAuthenticated]

--- a/application_form/models.py
+++ b/application_form/models.py
@@ -27,6 +27,8 @@ class Application(TimestampedModel):
         blank=True,
     )
 
+    audit_log_id_field = "external_uuid"
+
 
 class Applicant(TimestampedModel):
     first_name = models.CharField(_("first name"), max_length=30)

--- a/application_form/tests/conftest.py
+++ b/application_form/tests/conftest.py
@@ -9,7 +9,7 @@ from connections.tests.factories import ApartmentMinimalFactory
 faker.config.DEFAULT_LOCALE = "fi_FI"
 
 
-@fixture(scope="session")
+@fixture
 def api_client():
     return APIClient()
 

--- a/application_form/tests/test_application_api.py
+++ b/application_form/tests/test_application_api.py
@@ -1,8 +1,8 @@
-import json
 import pytest
 from django.urls import reverse
 
 from application_form.tests.utils import create_application_data
+from audit_log.tests.utils import get_audit_log_event
 from users.tests.factories import ProfileFactory
 from users.tests.utils import _create_token
 
@@ -27,8 +27,8 @@ def test_application_post_writes_audit_log(api_client, caplog):
     api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {_create_token(profile)}")
     data = create_application_data(profile)
     api_client.post(reverse("application_form:application-list"), data, format="json")
-    assert caplog.records, "no audit log entry was written"
-    audit_event = json.loads(caplog.records[-1].message)["audit_event"]
+    audit_event = get_audit_log_event(caplog)
+    assert audit_event is not None, "no audit log entry was written"
     assert audit_event["actor"] == {"role": "USER", "profile_id": str(profile.pk)}
     assert audit_event["operation"] == "CREATE"
     assert audit_event["target"] == {
@@ -53,8 +53,8 @@ def test_application_post_fails_if_not_authenticated(api_client):
 def test_application_post_writes_audit_log_if_not_authenticated(api_client, caplog):
     data = create_application_data(ProfileFactory())
     api_client.post(reverse("application_form:application-list"), data, format="json")
-    assert caplog.records, "no audit log entry was written"
-    audit_event = json.loads(caplog.records[-1].message)["audit_event"]
+    audit_event = get_audit_log_event(caplog)
+    assert audit_event is not None, "no audit log entry was written"
     assert audit_event["actor"] == {"role": "ANONYMOUS", "profile_id": None}
     assert audit_event["operation"] == "CREATE"
     assert audit_event["target"] == {"id": None, "type": "Application"}

--- a/application_form/tests/test_application_api.py
+++ b/application_form/tests/test_application_api.py
@@ -1,3 +1,4 @@
+import json
 import pytest
 from django.urls import reverse
 
@@ -21,9 +22,40 @@ def test_application_post(api_client):
 
 @pytest.mark.django_db
 @pytest.mark.usefixtures("elastic_apartments")
+def test_application_post_writes_audit_log(api_client, caplog):
+    profile = ProfileFactory()
+    api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {_create_token(profile)}")
+    data = create_application_data(profile)
+    api_client.post(reverse("application_form:application-list"), data, format="json")
+    assert caplog.records, "no audit log entry was written"
+    audit_event = json.loads(caplog.records[-1].message)["audit_event"]
+    assert audit_event["actor"] == {"role": "USER", "profile_id": str(profile.pk)}
+    assert audit_event["operation"] == "CREATE"
+    assert audit_event["target"] == {
+        "id": data["application_uuid"],
+        "type": "Application",
+    }
+    assert audit_event["status"] == "SUCCESS"
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("elastic_apartments")
 def test_application_post_fails_if_not_authenticated(api_client):
     data = create_application_data(ProfileFactory())
     response = api_client.post(
         reverse("application_form:application-list"), data, format="json"
     )
     assert response.status_code == 401
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("elastic_apartments")
+def test_application_post_writes_audit_log_if_not_authenticated(api_client, caplog):
+    data = create_application_data(ProfileFactory())
+    api_client.post(reverse("application_form:application-list"), data, format="json")
+    assert caplog.records, "no audit log entry was written"
+    audit_event = json.loads(caplog.records[-1].message)["audit_event"]
+    assert audit_event["actor"] == {"role": "ANONYMOUS", "profile_id": None}
+    assert audit_event["operation"] == "CREATE"
+    assert audit_event["target"] == {"id": None, "type": "Application"}
+    assert audit_event["status"] == "FORBIDDEN"

--- a/audit_log/audit_logging.py
+++ b/audit_log/audit_logging.py
@@ -61,10 +61,18 @@ def log(
             },
             "operation": str(operation.value),
             "target": {
-                "id": target and str(target.pk) or None,
+                "id": _get_target_id(target),
                 "type": target and str(target.__class__.__name__) or None,
             },
         },
     }
     logger = logging.getLogger("audit")
     logger.info(json.dumps(message))
+
+
+def _get_target_id(instance: Optional[Model]) -> Optional[str]:
+    if instance is None or instance.pk is None:
+        return None
+    field_name = getattr(instance, "audit_log_id_field", "pk")
+    audit_log_id = getattr(instance, field_name, None)
+    return str(audit_log_id)

--- a/audit_log/tests/utils.py
+++ b/audit_log/tests/utils.py
@@ -1,0 +1,13 @@
+from json import JSONDecodeError, loads
+from typing import Optional
+
+
+def get_audit_log_event(caplog) -> Optional[dict]:
+    for record in caplog.records:
+        try:
+            message = loads(record.message)
+            if "audit_event" in message:
+                return message["audit_event"]
+        except JSONDecodeError:
+            pass
+    return None

--- a/audit_log/viewsets.py
+++ b/audit_log/viewsets.py
@@ -1,0 +1,62 @@
+from copy import copy
+from django.contrib.auth.models import AnonymousUser
+from django.db.models import Model
+from rest_framework.viewsets import ModelViewSet
+from typing import Optional, Union
+
+from audit_log import audit_logging
+from audit_log.enums import Operation, Status
+from users.models import Profile
+
+
+class AuditLoggingModelViewSet(ModelViewSet):
+    method_to_operation = {
+        "POST": Operation.CREATE,
+        "GET": Operation.READ,
+        "PUT": Operation.UPDATE,
+        "PATCH": Operation.UPDATE,
+        "DELETE": Operation.DELETE,
+    }
+
+    def permission_denied(self, request, message=None, code=None):
+        audit_logging.log(
+            self._get_actor(),
+            self._get_operation(),
+            self._get_target(),
+            Status.FORBIDDEN,
+        )
+        super().permission_denied(request, message, code)
+
+    def retrieve(self, request, *args, **kwargs):
+        response = super().retrieve(request, *args, **kwargs)
+        audit_logging.log(self._get_actor(), Operation.READ, self._get_target())
+        return response
+
+    def perform_create(self, serializer):
+        super().perform_create(serializer)
+        audit_logging.log(self._get_actor(), Operation.CREATE, serializer.instance)
+
+    def perform_update(self, serializer):
+        super().perform_update(serializer)
+        audit_logging.log(self._get_actor(), Operation.UPDATE, serializer.instance)
+
+    def perform_destroy(self, instance):
+        actor = copy(self._get_actor())
+        target = copy(instance)
+        super().perform_destroy(instance)
+        audit_logging.log(actor, Operation.DELETE, target)
+
+    def _get_actor(self) -> Union[Profile, AnonymousUser]:
+        return getattr(self.request.user, "profile", self.request.user)
+
+    def _get_operation(self) -> Operation:
+        return self.method_to_operation[self.request.method]
+
+    def _get_target(self) -> Optional[Model]:
+        target = None
+        lookup_value = self.kwargs.get(self.lookup_field, None)
+        if lookup_value is not None:
+            target = self.queryset.model.objects.filter(
+                **{self.lookup_field: lookup_value}
+            ).first()
+        return target or self.queryset.model()

--- a/users/api/views.py
+++ b/users/api/views.py
@@ -1,18 +1,10 @@
-from copy import copy
 from django.contrib.auth import get_user_model
-from django.contrib.auth.models import AnonymousUser
-from django.db.models import Model
 from drf_spectacular.utils import extend_schema, extend_schema_view, OpenApiParameter
-from rest_framework import mixins, status
-from rest_framework.exceptions import NotAuthenticated, PermissionDenied
-from rest_framework.request import Request
+from rest_framework import status
 from rest_framework.response import Response
-from rest_framework.viewsets import GenericViewSet
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
-from typing import Optional, Union
 
-from audit_log import audit_logging
-from audit_log.enums import Operation, Status
+from audit_log.viewsets import AuditLoggingModelViewSet
 from users.api.permissions import IsCreatingOrAuthenticated
 from users.api.serializers import MaskedTokenObtainPairSerializer, ProfileSerializer
 from users.masking import mask_string, mask_uuid, unmask_uuid
@@ -29,49 +21,24 @@ MASKED_ID_PARAMETER = OpenApiParameter(
 
 @extend_schema_view(
     create=extend_schema(responses=ProfileSerializer.CreateResponseSerializer, auth=[]),
+    list=extend_schema(exclude=True),
     retrieve=extend_schema(parameters=[MASKED_ID_PARAMETER]),
     update=extend_schema(parameters=[MASKED_ID_PARAMETER]),
     destroy=extend_schema(parameters=[MASKED_ID_PARAMETER]),
 )
-class ProfileViewSet(
-    mixins.CreateModelMixin,
-    mixins.RetrieveModelMixin,
-    mixins.UpdateModelMixin,
-    mixins.DestroyModelMixin,
-    GenericViewSet,
-):
+class ProfileViewSet(AuditLoggingModelViewSet):
     queryset = Profile.objects.all()
     serializer_class = ProfileSerializer
     permission_classes = [IsCreatingOrAuthenticated]
     http_method_names = ["get", "post", "put", "delete"]
-    method_to_operation = {
-        "POST": Operation.CREATE,
-        "GET": Operation.READ,
-        "PUT": Operation.UPDATE,
-        "DELETE": Operation.DELETE,
-    }
-
-    def permission_denied(self, request, message=None, code=None):
-        try:
-            super().permission_denied(request, message, code)
-        except (NotAuthenticated, PermissionDenied):
-            actor = self._get_actor(request)
-            operation = self.method_to_operation[request.method]
-            target = self._get_target(request)
-            audit_logging.log(actor, operation, target, Status.FORBIDDEN)
-            raise
 
     def initial(self, request, *args, **kwargs):
         if self.lookup_field in self.kwargs:
             self.kwargs[self.lookup_field] = unmask_uuid(self.kwargs[self.lookup_field])
         super().initial(request, *args, **kwargs)
 
-    def retrieve(self, request, *args, **kwargs):
-        response = super(ProfileViewSet, self).retrieve(request, *args, **kwargs)
-        actor = self._get_actor(request)
-        target = self.get_object()
-        audit_logging.log(actor, Operation.READ, target)
-        return response
+    def list(self, request, *args, **kwargs):
+        return Response(status=status.HTTP_405_METHOD_NOT_ALLOWED)
 
     def create(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data)
@@ -79,29 +46,6 @@ class ProfileViewSet(
         self.perform_create(serializer)
         credentials = self._create_credentials(serializer.instance.user)
         return Response(credentials, status=status.HTTP_201_CREATED)
-
-    def perform_create(self, serializer):
-        super().perform_create(serializer)
-        audit_logging.log(
-            self._get_actor(self.request),
-            Operation.CREATE,
-            serializer.instance,
-        )
-
-    def perform_update(self, serializer):
-        super().perform_update(serializer)
-        audit_logging.log(
-            self._get_actor(self.request),
-            Operation.UPDATE,
-            serializer.instance,
-        )
-
-    def perform_destroy(self, instance):
-        # Actor or target (or both) may be gone after super().perform_destroy
-        actor = copy(self._get_actor(self.request))
-        target = copy(instance)
-        super().perform_destroy(instance)
-        audit_logging.log(actor, Operation.DELETE, target)
 
     def _create_credentials(self, user) -> dict:
         password = get_user_model().objects.make_random_password(length=32)
@@ -113,13 +57,6 @@ class ProfileViewSet(
             ),
             MaskedTokenObtainPairSerializer.password_field: mask_string(password),
         }
-
-    def _get_actor(self, request: Request) -> Union[Profile, AnonymousUser]:
-        return getattr(request.user, "profile", request.user)
-
-    def _get_target(self, request: Request) -> Optional[Model]:
-        profile_uuid = self.kwargs.get(self.lookup_field, None)
-        return Profile.objects.filter(pk=profile_uuid).first()
 
 
 @extend_schema_view(


### PR DESCRIPTION
This PR adds audit logging for applications.

Since there are now two viewsets where audit logging is used (profiles and applications), I extracted the audit logging logic into its own viewset that can be inherited. The new viewset automatically writes audit log events for all CRUD operations related to that view. This viewset is now used by both profile and application views.