### PR TITLE
Change Etuovi and Oikotie to use releases

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -3,8 +3,8 @@ django-cors-headers
 django-enumfields
 django-environ
 django-enumfields
-git+git://github.com/City-of-Helsinki/django-etuovi@develop#egg=django_etuovi  # TODO: change this when released in PyPI
-git+git://github.com/City-of-Helsinki/django-oikotie@develop#egg=django_oikotie  # TODO: change this when released in PyPI
+git+git://github.com/City-of-Helsinki/django-etuovi@v0.1.0#egg=django_etuovi  # TODO: change this when released in PyPI
+git+git://github.com/City-of-Helsinki/django-oikotie@v0.1.0#egg=django_oikotie  # TODO: change this when released in PyPI
 django-helusers<0.6.0  # TODO: update to version >=0.6.0
 django-ilmoitin~=0.5.0
 django-pgcrypto-fields

--- a/requirements.txt
+++ b/requirements.txt
@@ -60,9 +60,9 @@ django==2.2.24
     #   djangorestframework-simplejwt
     #   drf-oidc-auth
     #   drf-spectacular
-git+git://github.com/City-of-Helsinki/django-etuovi@develop#egg=django_etuovi
+git+git://github.com/City-of-Helsinki/django-etuovi@v0.1.0#egg=django_etuovi
     # via -r requirements.in
-git+git://github.com/City-of-Helsinki/django-oikotie@develop#egg=django_oikotie
+git+git://github.com/City-of-Helsinki/django-oikotie@v0.1.0#egg=django_oikotie
     # via -r requirements.in
 djangorestframework-simplejwt==4.7.1
     # via -r requirements.in


### PR DESCRIPTION
The development of Etuovi and Oikotie caused incompatibility in the
development as the specified version pointed into the develop branch
which is under development. This change is also MUST do that we'll be
using the release version in the future releases.