### PR TITLE
ASU-878 Add option for sending files separately

### DIFF
--- a/connections/management/commands/send_oikotie_xml_file.py
+++ b/connections/management/commands/send_oikotie_xml_file.py
@@ -27,37 +27,52 @@ class Command(BaseCommand):
             action="store_true",
             help="Only create XML files without sending them via FTP",
         )
+        parser.add_argument(
+            "--send_only_type",
+            type=int,
+            choices=[1, 2],
+            help="Send either housing company file (1) or apartment file (2)",
+        )
 
     def handle(self, *args, **options):
         path = settings.APARTMENT_DATA_TRANSFER_PATH
         apartments, housing_companies = fetch_apartments_for_sale()
-        apartment_file = create_xml_apartment_file(apartments)
-        housing_file = create_xml_housing_company_file(housing_companies)
+        sending_apartments = False
+        oikotie_files = []
+
+        if not options["send_only_type"] or options["send_only_type"] == 1:
+            oikotie_files.append(create_xml_housing_company_file(housing_companies))
+
+        if not options["send_only_type"] or options["send_only_type"] == 2:
+            sending_apartments = True
+            oikotie_files.append(create_xml_apartment_file(apartments))
 
         if options["only_create_files"]:
             _logger.info("Not sending XML files to Oikotie")
             return
 
-        if apartment_file and housing_file:
-            for f in [apartment_file, housing_file]:
-                try:
-                    send_items(path, f)
-                    _logger.info(
-                        f"Succefully sent XML file {path}/{f} to Oikotie FTP server"
-                    )
-                except Exception as e:
-                    _logger.error(
-                        f"File {path}/{f} sending via FTP to Oikotie failed:",
-                        str(e),
-                    )
-                    raise e
+        for oikotie_file in oikotie_files:
+            path = settings.APARTMENT_DATA_TRANSFER_PATH
+            try:
+                send_items(path, oikotie_file)
+                _logger.info(
+                    f"Successfully sent XML file {path}/{oikotie_file} to Oikotie FTP "
+                    "server"
+                )
+            except Exception as e:
+                _logger.error(
+                    f"File {path}/{oikotie_file} sending via FTP to Oikotie failed:",
+                    str(e),
+                )
+                raise e
 
-        MappedApartment.objects.exclude(
-            pk__in=[item.key for item in apartments]
-        ).update(mapped_oikotie=False)
+        if sending_apartments:
+            MappedApartment.objects.exclude(
+                pk__in=[item.key for item in apartments]
+            ).update(mapped_oikotie=False)
 
-        for item in apartments:
-            MappedApartment.objects.update_or_create(
-                apartment_uuid=item.key,
-                defaults={"mapped_oikotie": True},
-            )
+            for item in apartments:
+                MappedApartment.objects.update_or_create(
+                    apartment_uuid=item.key,
+                    defaults={"mapped_oikotie": True},
+                )

--- a/connections/tests/test_oikotie.py
+++ b/connections/tests/test_oikotie.py
@@ -350,3 +350,105 @@ class TestApartmentFetchingFromElasticAndMapping:
 
         assert ap_file_name is None
         assert hc_file_name is None
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("client", "elastic_apartments")
+class TestSendOikotieXMLFileCommand:
+    """
+    Tests for django command send_oikotie_xml_file with different parameters
+    """
+
+    @pytest.mark.usefixtures("not_sending_oikotie_ftp")
+    def test_send_oikotie_xml_file_only_create_files(self, test_folder):
+        """
+        Test that after calling send_oikotie_xml_file --only_create_files
+        files are created but no database entries are made
+        """
+
+        call_command("send_oikotie_xml_file", "--only_create_files")
+        files = os.listdir(test_folder)
+
+        assert any("APT" + settings.OIKOTIE_COMPANY_NAME in f for f in files)
+        assert any("HOUSINGCOMPANY" + settings.OIKOTIE_COMPANY_NAME in f for f in files)
+
+        oikotie_mapped = MappedApartment.objects.filter(mapped_oikotie=True).count()
+
+        assert oikotie_mapped == 0
+
+        for f in files:
+            os.remove(os.path.join(test_folder, f))
+
+    @pytest.mark.usefixtures("not_sending_oikotie_ftp")
+    def test_send_oikotie_xml_file_send_only_type_1(self, test_folder):
+        """
+        Test that after calling send_oikotie_xml_file --send_only_type 1
+        housing company file is created but database entries are not made.
+        """
+        call_command("send_oikotie_xml_file", "--send_only_type", 1)
+        files = os.listdir(test_folder)
+
+        assert any("HOUSINGCOMPANY" + settings.OIKOTIE_COMPANY_NAME in f for f in files)
+
+        oikotie_mapped = MappedApartment.objects.filter(mapped_oikotie=True).count()
+
+        assert oikotie_mapped == 0
+
+        for f in files:
+            os.remove(os.path.join(test_folder, f))
+
+    @pytest.mark.usefixtures("not_sending_oikotie_ftp")
+    def test_send_oikotie_xml_file_send_only_type_2(self, test_folder):
+        """
+        Test that after calling send_oikotie_xml_file --send_only_type 2
+        apartment file is created and no database entries are made.
+        """
+        call_command("send_oikotie_xml_file", "--send_only_type", 2)
+        files = os.listdir(test_folder)
+
+        assert any("APT" + settings.OIKOTIE_COMPANY_NAME in f for f in files)
+
+        oikotie_mapped = MappedApartment.objects.filter(mapped_oikotie=True)
+        expected = len(get_elastic_apartments_for_sale_uuids())
+
+        assert oikotie_mapped.count() == expected
+
+        for f in files:
+            os.remove(os.path.join(test_folder, f))
+
+    @pytest.mark.usefixtures("not_sending_oikotie_ftp")
+    def test_send_oikotie_xml_no_arguments(self, test_folder):
+        """
+        Test that after calling send_oikotie_xml_file without arguments
+        files are created and database entries are made
+        """
+        call_command("send_oikotie_xml_file")
+        files = os.listdir(test_folder)
+
+        assert any("APT" + settings.OIKOTIE_COMPANY_NAME in f for f in files)
+        assert any("HOUSINGCOMPANY" + settings.OIKOTIE_COMPANY_NAME in f for f in files)
+
+        oikotie_mapped = MappedApartment.objects.filter(mapped_oikotie=True)
+        expected = len(get_elastic_apartments_for_sale_uuids())
+
+        assert oikotie_mapped.count() == expected
+
+        for f in files:
+            os.remove(os.path.join(test_folder, f))
+
+    @pytest.mark.usefixtures("not_sending_oikotie_ftp")
+    def test_send_oikotie_xml_no_apartments(self, test_folder):
+        """
+        Test that after calling send_oikotie_xml_file with no apartments to map,
+        no files are created and no database entries are made
+        """
+        make_apartments_sold_in_elastic()
+
+        call_command("send_oikotie_xml_file")
+        files = os.listdir(test_folder)
+
+        assert not files
+
+        oikotie_mapped = MappedApartment.objects.filter(mapped_oikotie=True).count()
+
+        assert oikotie_mapped == 0


### PR DESCRIPTION
Oikotie accepts housing companies and apartments xml-files transfering
with 10 min delay between them. Updated command with flag to send either
one file.