### PR TITLE
ASU-365 Fix duplicate logging

### DIFF
--- a/apartment_application_service/settings.py
+++ b/apartment_application_service/settings.py
@@ -247,6 +247,7 @@ LOGGING = {
             "handlers": [
                 "console",
             ],
+            "propagate": False,
         },
         "connections": {
             "level": env("APPS_LOG_LEVEL"),


### PR DESCRIPTION
This PR fixes a minor issue with logging. Currently some log messages are duplicated in the logs:

```
2021-08-04 09:25:36,961 p29464 django.request WARNING: Unauthorized: /v1/profiles/
2021-08-04 09:25:36,961 p29464 django.request WARNING: Unauthorized: /v1/profiles/
2021-08-04 09:25:36,961 p29464 django.server WARNING: "GET /v1/profiles/ HTTP/1.1" 401 16074
2021-08-04 09:25:36,961 p29464 django.server WARNING: "GET /v1/profiles/ HTTP/1.1" 401 16074
```

This happens because the `django` logger is missing `"propagate": False`, which causes the root logger (`""`) to re-print the logs, doubling the log size.

The fix is to add `"propagate": False` to the logger. This fixes the log output:

```
2021-08-04 09:26:06,262 p29480 django.request WARNING: Unauthorized: /v1/profiles/
2021-08-04 09:26:06,262 p29480 django.server WARNING: "GET /v1/profiles/ HTTP/1.1" 401 16074
```