### PR TITLE
ASU-919 Fix integrity error if identifier already exists

### DIFF
--- a/application_form/services.py
+++ b/application_form/services.py
@@ -30,7 +30,7 @@ def create_application(application_data: dict) -> Application:
     Identifier.objects.get_or_create(
         schema_type=IdentifierSchemaType.ATT_PROJECT_ES,
         identifier=project_id,
-        project=project,
+        defaults={"project": project},
     )
     additional_applicant_data = data.pop("additional_applicant")
     application = Application.objects.create(
@@ -86,7 +86,7 @@ def create_application(application_data: dict) -> Application:
         Identifier.objects.get_or_create(
             schema_type=IdentifierSchemaType.ATT_PROJECT_ES,
             identifier=apartment_item["identifier"],
-            apartment=apartment,
+            defaults={"apartment": apartment},
         )
     _logger.debug(
         "Application created with external UUID %s", application_data["external_uuid"]


### PR DESCRIPTION
This PR fixes a bug with creating applications. I found this bug while developing our load testing script.

If a project or an apartment has already appeared in some previous application, creating a new application with the same project or apartment may fail with an integrity error:

```
IntegrityError

duplicate key value violates unique constraint "apartment_identifier_schema_type_identifier_72712817_uniq"
DETAIL:  Key (schema_type, identifier)=(att_pro_es, c50c112d-c14a-4768-a2ce-c76b0e19456e) already exists.
```
The problem is in `create_application`, which uses Django's `get_or_create` slightly wrong way. The code was trying to create a new record for project and apartment identifiers every time, even if an identifier for the project or apartment may already exist in the database.

I added two test cases to reproduce the issue for project identifier and apartment identifier to make sure it doesn't happen again.