### PR TITLE
Add postgres client to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,11 @@ COPY --chown=appuser:appuser requirements.txt /app/requirements.txt
 COPY --chown=appuser:appuser requirements-prod.txt /app/requirements-prod.txt
 
 RUN apt-install.sh \
-        git \
-        netcat \
-        libpq-dev \
-        build-essential \
+    git \
+    postgresql-client \
+    netcat \
+    libpq-dev \
+    build-essential \
     && pip install -U pip \
     && pip install --no-cache-dir -r /app/requirements.txt \
     && pip install --no-cache-dir  -r /app/requirements-prod.txt \
@@ -37,8 +38,8 @@ FROM appbase as development
 
 COPY --chown=appuser:appuser requirements-dev.txt /app/requirements-dev.txt
 RUN apt-install.sh \
-        build-essential \
-        ssh-client \
+    build-essential \
+    ssh-client \
     && pip install --no-cache-dir -r /app/requirements-dev.txt \
     && apt-cleanup.sh build-essential
 


### PR DESCRIPTION
Postgres client is needed for Django dbshell command and for pod's shell
to manage the database.