### PR TITLE
Add default AutoField to Settings

### DIFF
--- a/apartment_application_service/settings.py
+++ b/apartment_application_service/settings.py
@@ -87,6 +87,7 @@ ALLOWED_HOSTS = env.list("ALLOWED_HOSTS")
 USE_X_FORWARDED_HOST = env.bool("USE_X_FORWARDED_HOST")
 
 DATABASES = {"default": env.db()}
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 CACHES = {"default": env.cache()}
 


### PR DESCRIPTION
Django 3.2 requires that the default AutoField is defined to settings,
otherwise, it provides a warning message.

By default, Django generates the new projects to use BigAutoField so in
this we follow the same thing.