### PR TITLE
Improve the project API view

### DIFF
--- a/apartment/api/serializers.py
+++ b/apartment/api/serializers.py
@@ -60,6 +60,7 @@ class ProjectDocumentSerializer(serializers.Serializer):
     new_housing = serializers.BooleanField(source="project_new_housing")
     apartment_count = serializers.IntegerField(source="project_apartment_count")
     parkingplace_count = serializers.IntegerField(source="project_parkingplace_count")
+    state_of_sale = serializers.CharField(source="project_state_of_sale")
     has_elevator = serializers.BooleanField(source="project_has_elevator")
     has_sauna = serializers.BooleanField(source="project_has_sauna")
     construction_materials = serializers.ListField(

--- a/apartment/api/views.py
+++ b/apartment/api/views.py
@@ -29,6 +29,7 @@ class ProjectAPIView(APIView):
     http_method_names = ["get"]
 
     def get(self, request):
-        projects = get_projects()
+        project_uuid = request.GET.get("project_uuid", None)
+        projects = get_projects(project_uuid)
         serializer = ProjectDocumentSerializer(projects, many=True)
         return Response(serializer.data)

--- a/apartment/api/views.py
+++ b/apartment/api/views.py
@@ -1,5 +1,4 @@
 from rest_framework import permissions
-from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -24,7 +23,10 @@ class ApartmentAPIView(APIView):
 
 
 class ProjectAPIView(APIView):
-    permission_classes = [IsAuthenticated]
+    permission_classes = [
+        permissions.AllowAny,
+    ]
+    http_method_names = ["get"]
 
     def get(self, request):
         projects = get_projects()

--- a/apartment/api/views.py
+++ b/apartment/api/views.py
@@ -1,6 +1,4 @@
 from rest_framework import permissions
-from rest_framework.generics import GenericAPIView
-from rest_framework.mixins import ListModelMixin
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -25,12 +23,10 @@ class ApartmentAPIView(APIView):
         return Response(serializer.data)
 
 
-class ProjectAPIView(ListModelMixin, GenericAPIView):
+class ProjectAPIView(APIView):
     permission_classes = [IsAuthenticated]
-    serializer_class = ProjectDocumentSerializer
 
-    def get_queryset(self):
-        return get_projects()
-
-    def get(self, request, *args, **kwargs):
-        return self.list(request, *args, **kwargs)
+    def get(self, request):
+        projects = get_projects()
+        serializer = ProjectDocumentSerializer(projects, many=True)
+        return Response(serializer.data)

--- a/apartment/elastic/documents.py
+++ b/apartment/elastic/documents.py
@@ -34,6 +34,7 @@ class ApartmentDocument(ReadOnlyDocument):
     project_new_housing = Boolean(required=True)
     project_apartment_count = Long(required=True)
     project_parkingplace_count = Long()
+    project_state_of_sale = Keyword()
 
     project_has_elevator = Boolean()
     project_has_sauna = Boolean()

--- a/apartment/elastic/queries.py
+++ b/apartment/elastic/queries.py
@@ -20,10 +20,15 @@ def get_apartments(project_uuid=None):
     return response
 
 
-def get_projects():
+def get_projects(project_uuid=None):
+    search = ApartmentDocument.search()
+
+    # Filters
+    if project_uuid:
+        search = search.filter("term", project_uuid__keyword=project_uuid)
+
     # Project data needs to exist in apartment data
-    query = Q("bool", must=Q("exists", field="project_id"))
-    search = ApartmentDocument.search().query(query)
+    search = search.query(Q("bool", must=Q("exists", field="project_id")))
 
     # Get only most recent apartment which has project data
     search = search.extra(

--- a/apartment/elastic/queries.py
+++ b/apartment/elastic/queries.py
@@ -1,5 +1,3 @@
-from elasticsearch_dsl import Q
-
 from apartment.elastic.documents import ApartmentDocument
 
 
@@ -8,7 +6,7 @@ def get_apartments(project_uuid=None):
 
     # Filters
     if project_uuid:
-        search = search.query("match", project_uuid=project_uuid)
+        search = search.filter("term", project_uuid__keyword=project_uuid)
 
     # Exclude project fields
     search = search.source(excludes=["project_*"])
@@ -28,7 +26,7 @@ def get_projects(project_uuid=None):
         search = search.filter("term", project_uuid__keyword=project_uuid)
 
     # Project data needs to exist in apartment data
-    search = search.query(Q("bool", must=Q("exists", field="project_id")))
+    search = search.filter("exists", field="project_id")
 
     # Get only most recent apartment which has project data
     search = search.extra(

--- a/apartment/elastic/queries.py
+++ b/apartment/elastic/queries.py
@@ -40,5 +40,8 @@ def get_projects():
     # Retrieve only project fields
     search = search.source(["project_*"])
 
-    response = search.execute()
+    # Get all items
+    count = search.count()
+    response = search[0:count].execute()
+
     return response

--- a/apartment/tests/api/test_views.py
+++ b/apartment/tests/api/test_views.py
@@ -43,3 +43,20 @@ def test_project_list_get(api_client):
     response = api_client.get(reverse("apartment:project-list"), format="json")
     assert response.status_code == 200
     assert len(response.data) > 0
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("elastic_apartments")
+def test_project_get_with_project_uuid(api_client):
+    apartment = ApartmentDocumentFactory(project_uuid=uuid.uuid4())
+    profile = ProfileFactory()
+    api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {_create_token(profile)}")
+    data = {"project_uuid": apartment.project_uuid}
+    response = api_client.get(
+        reverse("apartment:project-list"),
+        data=data,
+        format="json",
+    )
+    assert response.status_code == 200
+    assert len(response.data) == 1
+    assert response.data[0].get("uuid") == str(apartment.project_uuid)

--- a/apartment/tests/api/test_views.py
+++ b/apartment/tests/api/test_views.py
@@ -21,7 +21,6 @@ def test_apartment_list_get(api_client):
 @pytest.mark.usefixtures("elastic_apartments")
 def test_apartment_list_get_with_project_uuid(api_client):
     apartment = ApartmentDocumentFactory(project_uuid=uuid.uuid4())
-    # apartment.save(refresh="wait_for")
     profile = ProfileFactory()
     api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {_create_token(profile)}")
     data = {"project_uuid": apartment.project_uuid}

--- a/apartment/tests/factories.py
+++ b/apartment/tests/factories.py
@@ -155,6 +155,9 @@ class ApartmentDocumentFactory(ElasticFactory):
     project_new_housing = True
     project_apartment_count = fuzzy.FuzzyInteger(0, 999)
     project_parkingplace_count = fuzzy.FuzzyInteger(0, 999)
+    project_state_of_sale = fuzzy.FuzzyChoice(
+        ["PRE_MARKETING", "FOR_SALE", "PROCESSING", "READY"]
+    )
 
     project_has_elevator = True
     project_has_sauna = True


### PR DESCRIPTION
* Change ProjectAPIView to use APIView parent (similarly in ApartmentAPIView)
* Remove authentication from the ProjectAPIView (permissions check will be added later when the authentication works)
* Get all the project data from elasticsearch. Currently, it returns only 10 items.
* Add API endpoint to get a single project item
* Use the filter in Apartment and Project search
* Add missing project_state_of_sale field to Project document and endpoint.