### PR TITLE
Return single item instead array in Project API

### DIFF
--- a/apartment/api/views.py
+++ b/apartment/api/views.py
@@ -29,8 +29,7 @@ class ProjectAPIView(APIView):
     ]
     http_method_names = ["get"]
 
-    def get(self, request):
-        project_uuid = request.GET.get("project_uuid", None)
+    def get(self, request, project_uuid=None):
         many = project_uuid is None
         project_data = get_projects(project_uuid)
         if not many:

--- a/apartment/api/views.py
+++ b/apartment/api/views.py
@@ -1,4 +1,5 @@
 from rest_framework import permissions
+from rest_framework.exceptions import NotFound
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -30,6 +31,12 @@ class ProjectAPIView(APIView):
 
     def get(self, request):
         project_uuid = request.GET.get("project_uuid", None)
-        projects = get_projects(project_uuid)
-        serializer = ProjectDocumentSerializer(projects, many=True)
+        many = project_uuid is None
+        project_data = get_projects(project_uuid)
+        if not many:
+            if len(project_data) == 1:
+                project_data = project_data[0]
+            else:
+                raise NotFound()
+        serializer = ProjectDocumentSerializer(project_data, many=many)
         return Response(serializer.data)

--- a/apartment/tests/api/test_views.py
+++ b/apartment/tests/api/test_views.py
@@ -50,10 +50,10 @@ def test_project_get_with_project_uuid(api_client):
     apartment = ApartmentDocumentFactory(project_uuid=uuid.uuid4())
     profile = ProfileFactory()
     api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {_create_token(profile)}")
-    data = {"project_uuid": apartment.project_uuid}
     response = api_client.get(
-        reverse("apartment:project-list"),
-        data=data,
+        reverse(
+            "apartment:project-list", kwargs={"project_uuid": apartment.project_uuid}
+        ),
         format="json",
     )
     assert response.status_code == 200
@@ -66,10 +66,8 @@ def test_project_get_with_project_uuid(api_client):
 def test_project_get_with_project_uuid_not_exist(api_client):
     profile = ProfileFactory()
     api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {_create_token(profile)}")
-    data = {"project_uuid": uuid.uuid4()}
     response = api_client.get(
-        reverse("apartment:project-list"),
-        data=data,
+        reverse("apartment:project-list", kwargs={"project_uuid": uuid.uuid4()}),
         format="json",
     )
     assert response.status_code == 404

--- a/apartment/tests/api/test_views.py
+++ b/apartment/tests/api/test_views.py
@@ -57,5 +57,19 @@ def test_project_get_with_project_uuid(api_client):
         format="json",
     )
     assert response.status_code == 200
-    assert len(response.data) == 1
-    assert response.data[0].get("uuid") == str(apartment.project_uuid)
+    assert response.data
+    assert response.data.get("uuid") == str(apartment.project_uuid)
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("elastic_apartments")
+def test_project_get_with_project_uuid_not_exist(api_client):
+    profile = ProfileFactory()
+    api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {_create_token(profile)}")
+    data = {"project_uuid": uuid.uuid4()}
+    response = api_client.get(
+        reverse("apartment:project-list"),
+        data=data,
+        format="json",
+    )
+    assert response.status_code == 404

--- a/apartment/urls.py
+++ b/apartment/urls.py
@@ -7,6 +7,15 @@ router = DefaultRouter()
 
 urlpatterns = [
     path("sales/apartments/", ApartmentAPIView.as_view(), name="apartment-list"),
-    path("sales/projects/", ProjectAPIView.as_view(), name="project-list"),
+    path(
+        "sales/projects/",
+        ProjectAPIView.as_view(),
+        name="project-list",
+    ),
+    path(
+        "sales/projects/(?<uuid:project_uuid>)/",
+        ProjectAPIView.as_view(),
+        name="project-list",
+    ),
     path("", include(router.urls)),
 ]


### PR DESCRIPTION
* If the API is called with the project_uuid parameter, then return
the single item.
* Add project_uuid to URL parameters in project API