### PR TITLE
Test: Refactor, simplify and fix the unit tests

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,2 +1,3 @@
 sonar.exclusions=**/migrations/**/*, **/tests/**/*
 sonar.projectKey=City-of-Helsinki_apartment-application-service
+sonar.python.version=3

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,2 @@
+sonar.exclusions=**/migrations/**/*, **/tests/**/*
+sonar.projectKey=City-of-Helsinki_apartment-application-service

--- a/apartment/tests/conftest.py
+++ b/apartment/tests/conftest.py
@@ -1,7 +1,8 @@
 import faker.config
-from elasticsearch.helpers.test import get_test_client, SkipTest
-from elasticsearch_dsl.connections import add_connection, get_connection
-from pytest import fixture, skip
+from django.conf import settings
+from elasticsearch.helpers.test import get_test_client
+from elasticsearch_dsl.connections import add_connection
+from pytest import fixture
 from rest_framework.test import APIClient
 
 from apartment.tests.factories import ApartmentDocumentFactory
@@ -15,18 +16,27 @@ def api_client():
     return api_client
 
 
-@fixture(autouse=True, scope="session")
-def elastic_client():
-    try:
-        connection = get_test_client()
-        add_connection("default", connection)
-        yield connection
-    except SkipTest:
-        skip()
+def setup_elasticsearch():
+    test_client = get_test_client()
+    add_connection("default", test_client)
+    if test_client.indices.exists(index=settings.APARTMENT_INDEX_NAME):
+        test_client.indices.delete(index=settings.APARTMENT_INDEX_NAME)
+    test_client.indices.create(index=settings.APARTMENT_INDEX_NAME)
+    return test_client
 
 
-@fixture(scope="session")
-def elastic_apartments():
-    connection = get_connection()
-    connection.indices.delete("test-*", ignore=404)
+def teardown_elasticsearch(test_client):
+    if test_client.indices.exists(index=settings.APARTMENT_INDEX_NAME):
+        test_client.indices.delete(index=settings.APARTMENT_INDEX_NAME)
+
+
+@fixture(scope="module")
+def elasticsearch():
+    test_client = setup_elasticsearch()
+    yield test_client
+    teardown_elasticsearch(test_client)
+
+
+@fixture(scope="module")
+def elastic_apartments(elasticsearch):
     yield ApartmentDocumentFactory.create_batch(10)

--- a/apartment/tests/factories.py
+++ b/apartment/tests/factories.py
@@ -1,6 +1,5 @@
 import factory
 import string
-import uuid
 from datetime import date
 from django.utils import timezone
 from elasticsearch_dsl import Document
@@ -71,7 +70,7 @@ class ApartmentFactory(factory.django.DjangoModelFactory):
         if identifier_schema == "att":
             identifiers = [
                 IdentifierFactory(
-                    identifier=factory.Sequence(lambda n: "%s" % uuid.uuid4()),
+                    identifier=factory.Faker("uuid4"),
                     schema_type=IdentifierSchemaType.ATT_PROJECT_ES,
                     apartment=None,
                     project=None,
@@ -120,10 +119,6 @@ class ApartmentDocumentTest(ApartmentDocument):
         name = "test-apartment"
 
 
-def get_uuid():
-    return str(uuid.uuid4())
-
-
 class ElasticFactory(factory.Factory):
     @factory.post_generation
     def save_to_elastic(obj, create, extracted, **kwargs):
@@ -138,7 +133,7 @@ class ApartmentDocumentFactory(ElasticFactory):
 
     _language = fuzzy.FuzzyChoice(["en", "fi", "sv"])
     project_id = fuzzy.FuzzyInteger(0, 999)
-    project_uuid = str(uuid.uuid4())
+    project_uuid = factory.Faker("uuid4")
 
     project_ownership_type = fuzzy.FuzzyChoice(["Haso", "Hitas", "Puolihitas"])
     project_housing_company = fuzzy.FuzzyText()
@@ -225,7 +220,7 @@ class ApartmentDocumentFactory(ElasticFactory):
         ]
     )
 
-    uuid = fuzzy.FuzzyAttribute(get_uuid)
+    uuid = factory.Faker("uuid4")
 
     apartment_address = fuzzy.FuzzyText()
     apartment_number = fuzzy.FuzzyText(

--- a/apartment/tests/factories.py
+++ b/apartment/tests/factories.py
@@ -98,7 +98,7 @@ class IdentifierFactory(factory.django.DjangoModelFactory):
     def build_batch_for_att_schema(cls, size: int, uuids_list: list):
         return [
             cls.build(
-                identifier=uuids_list[i],
+                identifier=str(uuids_list[i]),
                 schema_type=IdentifierSchemaType.ATT_PROJECT_ES,
             )
             for i in range(size)

--- a/application_form/api/serializers.py
+++ b/application_form/api/serializers.py
@@ -45,7 +45,7 @@ class ApplicantSerializer(serializers.ModelSerializer):
 
 class ApplicationApartmentSerializer(serializers.Serializer):
     priority = IntegerField(min_value=0, max_value=5)
-    identifier = CharField()
+    identifier = UUIDField()
 
 
 class ApplicationSerializer(serializers.ModelSerializer):

--- a/application_form/services/lottery/hitas.py
+++ b/application_form/services/lottery/hitas.py
@@ -84,7 +84,7 @@ def _shuffle_queue_segment(
     # Create a list of all possible queue positions between start and end position
     possible_positions = list(range(start_position, end_position))
 
-    for app_apartment in application_apartments.all():
+    for app_apartment in application_apartments.order_by("id").all():
         # Remove a random queue position from the list assign it to the application
         random_index = secrets.randbelow(len(possible_positions))
         position = possible_positions.pop(random_index)

--- a/application_form/tests/conftest.py
+++ b/application_form/tests/conftest.py
@@ -39,3 +39,26 @@ def elasticsearch():
 @fixture(scope="module")
 def elastic_apartments(elasticsearch):
     yield ApartmentMinimalFactory.create_for_sale_batch(10)
+
+
+@fixture
+def elastic_single_project_with_apartments(elasticsearch):
+    apartments = []
+    apartments.append(
+        ApartmentMinimalFactory(
+            apartment_state_of_sale="FOR_SALE",
+            _language="fi",
+        )
+    )
+    for _ in range(10):
+        apartments.append(
+            ApartmentMinimalFactory(
+                apartment_state_of_sale="FOR_SALE",
+                _language="fi",
+                project_uuid=apartments[0].project_uuid,
+            )
+        )
+    yield apartments
+
+    for apartment in apartments:
+        apartment.delete(refresh=True)

--- a/application_form/tests/test_application_api.py
+++ b/application_form/tests/test_application_api.py
@@ -8,8 +8,7 @@ from users.tests.utils import _create_token
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("elastic_apartments")
-def test_application_post(api_client):
+def test_application_post(api_client, elastic_single_project_with_apartments):
     profile = ProfileFactory()
     api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {_create_token(profile)}")
     data = create_application_data(profile)
@@ -21,8 +20,9 @@ def test_application_post(api_client):
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("elastic_apartments")
-def test_application_post_writes_audit_log(api_client):
+def test_application_post_writes_audit_log(
+    api_client, elastic_single_project_with_apartments
+):
     profile = ProfileFactory()
     api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {_create_token(profile)}")
     data = create_application_data(profile)
@@ -38,8 +38,9 @@ def test_application_post_writes_audit_log(api_client):
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("elastic_apartments")
-def test_application_post_fails_if_not_authenticated(api_client):
+def test_application_post_fails_if_not_authenticated(
+    api_client, elastic_single_project_with_apartments
+):
     data = create_application_data(ProfileFactory())
     response = api_client.post(
         reverse("application_form:application-list"), data, format="json"
@@ -48,8 +49,9 @@ def test_application_post_fails_if_not_authenticated(api_client):
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("elastic_apartments")
-def test_application_post_writes_audit_log_if_not_authenticated(api_client):
+def test_application_post_writes_audit_log_if_not_authenticated(
+    api_client, elastic_single_project_with_apartments
+):
     data = create_application_data(ProfileFactory())
     api_client.post(reverse("application_form:application-list"), data, format="json")
     audit_event = AuditLog.objects.get().message["audit_event"]

--- a/application_form/tests/test_application_services.py
+++ b/application_form/tests/test_application_services.py
@@ -15,9 +15,8 @@ from users.tests.factories import ProfileFactory
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("elastic_apartments")
 @pytest.mark.parametrize("num_applicants", [1, 2])
-def test_create_application(num_applicants):
+def test_create_application(num_applicants, elastic_single_project_with_apartments):
     profile = ProfileFactory()
     data = create_validated_application_data(
         profile, ApplicationType.HASO, num_applicants
@@ -85,9 +84,10 @@ def test_create_application(num_applicants):
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("elastic_apartments")
 @pytest.mark.parametrize("application_type", list(ApplicationType))
-def test_create_application_type(application_type):
+def test_create_application_type(
+    application_type, elastic_single_project_with_apartments
+):
     profile = ProfileFactory()
     data = create_validated_application_data(profile, application_type)
     application = create_application(data)
@@ -95,8 +95,9 @@ def test_create_application_type(application_type):
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("elastic_apartments")
-def test_create_application_raises_exception_if_apartment_data_does_not_exist():
+def test_create_application_raises_exception_if_apartment_data_does_not_exist(
+    elastic_single_project_with_apartments,
+):
     data = create_validated_application_data(ProfileFactory(), ApplicationType.HASO)
     data["apartments"] = [{"priority": 1, "identifier": "this-does-not-exist"}]
     with pytest.raises(InvalidElasticDataError):
@@ -104,8 +105,9 @@ def test_create_application_raises_exception_if_apartment_data_does_not_exist():
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("elastic_apartments")
-def test_create_application_raises_exception_if_project_data_does_not_exist():
+def test_create_application_raises_exception_if_project_data_does_not_exist(
+    elastic_single_project_with_apartments,
+):
     data = create_validated_application_data(ProfileFactory(), ApplicationType.HASO)
     data["project_id"] = "this-does-not-exist"
     with pytest.raises(InvalidElasticDataError):
@@ -113,8 +115,9 @@ def test_create_application_raises_exception_if_project_data_does_not_exist():
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("elastic_apartments")
-def test_create_application_does_not_fail_if_project_identifier_already_exists():
+def test_create_application_does_not_fail_if_project_identifier_already_exists(
+    elastic_single_project_with_apartments,
+):
     data = create_validated_application_data(ProfileFactory(), ApplicationType.HASO)
     Identifier.objects.create(
         schema_type=IdentifierSchemaType.ATT_PROJECT_ES,
@@ -130,8 +133,9 @@ def test_create_application_does_not_fail_if_project_identifier_already_exists()
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("elastic_apartments")
-def test_create_application_does_not_fail_if_apartment_identifier_already_exists():
+def test_create_application_does_not_fail_if_apartment_identifier_already_exists(
+    elastic_single_project_with_apartments,
+):
     data = create_validated_application_data(ProfileFactory(), ApplicationType.HASO)
     for apartment in data["apartments"]:
         Identifier.objects.create(
@@ -148,8 +152,9 @@ def test_create_application_does_not_fail_if_apartment_identifier_already_exists
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("elastic_apartments")
-def test_create_application_adds_haso_application_to_queue_by_right_of_residence():
+def test_create_application_adds_haso_application_to_queue_by_right_of_residence(
+    elastic_single_project_with_apartments,
+):
     data = create_validated_application_data(ProfileFactory(), ApplicationType.HASO)
     application2 = create_application({**data, "right_of_residence": 2})
     application1 = create_application({**data, "right_of_residence": 1})
@@ -158,8 +163,9 @@ def test_create_application_adds_haso_application_to_queue_by_right_of_residence
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("elastic_apartments")
-def test_create_application_adds_hitas_application_to_queue_by_application_order():
+def test_create_application_adds_hitas_application_to_queue_by_application_order(
+    elastic_single_project_with_apartments,
+):
     data = create_validated_application_data(ProfileFactory(), ApplicationType.HITAS)
     application2 = create_application({**data, "right_of_residence": 2})
     application1 = create_application({**data, "right_of_residence": 1})

--- a/application_form/tests/test_sales_application_api.py
+++ b/application_form/tests/test_sales_application_api.py
@@ -10,8 +10,9 @@ from users.tests.utils import _create_token
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("elastic_apartments")
-def test_sales_application_post_without_permission(api_client):
+def test_sales_application_post_without_permission(
+    api_client, elastic_single_project_with_apartments
+):
     profile = ProfileFactory()
     api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {_create_token(profile)}")
     data = create_application_data(profile)
@@ -22,8 +23,7 @@ def test_sales_application_post_without_permission(api_client):
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("elastic_apartments")
-def test_sales_application_post(api_client):
+def test_sales_application_post(api_client, elastic_single_project_with_apartments):
     salesperson_profile = ProfileFactory()
     salesperson_group = Group.objects.get(name__iexact=Roles.SALESPERSON.name)
     salesperson_group.user_set.add(salesperson_profile.user)

--- a/application_form/tests/utils.py
+++ b/application_form/tests/utils.py
@@ -16,8 +16,8 @@ _logger = logging.getLogger(__name__)
 def get_elastic_apartments_uuids() -> Tuple[uuid.UUID, List[uuid.UUID]]:
     s_obj = (
         Search()
-        .query("match", _language="fi")
-        .query("match", apartment_state_of_sale=ApartmentStateOfSale.FOR_SALE)
+        .filter("term", _language__keyword="fi")
+        .filter("term", apartment_state_of_sale__keyword=ApartmentStateOfSale.FOR_SALE)
     )
     s_obj.execute()
     scan = s_obj.scan()

--- a/application_form/tests/utils.py
+++ b/application_form/tests/utils.py
@@ -1,8 +1,8 @@
 import logging
+import uuid
 from elasticsearch_dsl import Search
 from typing import List, Tuple
 from unittest.mock import Mock
-from uuid import uuid4
 
 from apartment.tests.factories import IdentifierFactory
 from application_form.api.serializers import ApplicationSerializer
@@ -13,7 +13,7 @@ from connections.enums import ApartmentStateOfSale
 _logger = logging.getLogger(__name__)
 
 
-def get_elastic_apartments_uuids() -> Tuple[str, List[str]]:
+def get_elastic_apartments_uuids() -> Tuple[uuid.UUID, List[uuid.UUID]]:
     s_obj = (
         Search()
         .query("match", _language="fi")
@@ -25,9 +25,9 @@ def get_elastic_apartments_uuids() -> Tuple[str, List[str]]:
     project_uuid = None
     for hit in scan:
         if not project_uuid:
-            project_uuid = str(hit.project_uuid)
-        if project_uuid == hit.project_uuid:
-            uuids.append(str(hit.uuid))
+            project_uuid = uuid.UUID(hit.project_uuid)
+        if project_uuid == uuid.UUID(hit.project_uuid):
+            uuids.append(uuid.UUID(hit.uuid))
     return project_uuid, uuids
 
 
@@ -45,13 +45,13 @@ def create_application_data(
 
     # Build application request data
     application_data = {
-        "application_uuid": str(uuid4()),
+        "application_uuid": str(uuid.uuid4()),
         "application_type": application_type.value,
         "ssn_suffix": calculate_ssn_suffix(profile),
         "has_children": True,
         "right_of_residence": right_of_residence,
         "additional_applicant": None,
-        "project_id": project_uuid,
+        "project_id": str(project_uuid),
         "apartments": apartments_data,
     }
     # Add a second applicant if needed

--- a/application_form/tests/utils.py
+++ b/application_form/tests/utils.py
@@ -22,11 +22,12 @@ def get_elastic_apartments_uuids() -> Tuple[str, List[str]]:
     s_obj.execute()
     scan = s_obj.scan()
     uuids = []
-    project_uuid = ""
-    while len(uuids) <= 5:
-        for hit in scan:
-            uuids.append(str(hit.uuid))
+    project_uuid = None
+    for hit in scan:
+        if not project_uuid:
             project_uuid = str(hit.project_uuid)
+        if project_uuid == hit.project_uuid:
+            uuids.append(str(hit.uuid))
     return project_uuid, uuids
 
 

--- a/connections/etuovi/services.py
+++ b/connections/etuovi/services.py
@@ -17,9 +17,9 @@ def fetch_apartments_for_sale() -> list:
     """
     s_obj = (
         ApartmentDocument.search()
-        .query("match", _language="fi")
-        .query("match", apartment_state_of_sale=ApartmentStateOfSale.FOR_SALE)
-        .query("match", publish_on_etuovi=True)
+        .filter("term", _language__keyword="fi")
+        .filter("term", apartment_state_of_sale__keyword=ApartmentStateOfSale.FOR_SALE)
+        .filter("term", publish_on_etuovi=True)
     )
     s_obj.execute()
     scan = s_obj.scan()

--- a/connections/oikotie/services.py
+++ b/connections/oikotie/services.py
@@ -20,9 +20,9 @@ def fetch_apartments_for_sale() -> Tuple[list, list]:
     """
     s_obj = (
         ApartmentDocument.search()
-        .query("match", _language="fi")
-        .query("match", apartment_state_of_sale=ApartmentStateOfSale.FOR_SALE)
-        .query("match", publish_on_oikotie=True)
+        .filter("term", _language__keyword="fi")
+        .filter("term", apartment_state_of_sale__keyword=ApartmentStateOfSale.FOR_SALE)
+        .filter("term", publish_on_oikotie=True)
     )
     s_obj.execute()
     scan = s_obj.scan()

--- a/connections/oikotie/services.py
+++ b/connections/oikotie/services.py
@@ -2,9 +2,9 @@ import logging
 import os
 from django.conf import settings
 from django_oikotie.oikotie import create_apartments, create_housing_companies
-from elasticsearch_dsl import Search
 from typing import Optional, Tuple
 
+from apartment.elastic.documents import ApartmentDocument
 from connections.enums import ApartmentStateOfSale
 from connections.oikotie.oikotie_mapper import (
     map_oikotie_apartment,
@@ -19,7 +19,7 @@ def fetch_apartments_for_sale() -> Tuple[list, list]:
     Fetch apartments for sale from elasticsearch and map them for Oikotie
     """
     s_obj = (
-        Search()
+        ApartmentDocument.search()
         .query("match", _language="fi")
         .query("match", apartment_state_of_sale=ApartmentStateOfSale.FOR_SALE)
         .query("match", publish_on_oikotie=True)

--- a/connections/service/elastic.py
+++ b/connections/service/elastic.py
@@ -60,7 +60,7 @@ def _create_or_update_project(elastic_project: ElasticApartment) -> Project:
 
 
 def _get_elastic_apartment_data(identifier: uuid.UUID) -> ElasticApartment:
-    s = ElasticApartment.search().query("match", uuid=identifier)
+    s = ElasticApartment.search().filter("term", uuid__keyword=identifier)
     s.execute()
     objects = list(s.scan())
 
@@ -83,7 +83,7 @@ def _get_elastic_apartment_data(identifier: uuid.UUID) -> ElasticApartment:
 
 
 def _get_elastic_project_data(identifier: uuid.UUID) -> ElasticApartment:
-    s = ElasticApartment.search().query("match", project_uuid=identifier)
+    s = ElasticApartment.search().filter("term", project_uuid__keyword=identifier)
     s.execute()
     objects = list(s.scan())
 

--- a/connections/tests/conftest.py
+++ b/connections/tests/conftest.py
@@ -118,7 +118,7 @@ def invalid_data_elastic_apartments_for_sale():
     # oikotie housing company invalid data is in project_estate_agent_email
 
     # should fail with oikotie apartments and etuovi
-    elastic_apartment_1 = ApartmentMinimalFactory.build(
+    elastic_apartment_1 = ApartmentMinimalFactory.create(
         project_holding_type="some text",
         project_new_development_status="some text",
         apartment_state_of_sale=ApartmentStateOfSale.FOR_SALE,
@@ -127,7 +127,7 @@ def invalid_data_elastic_apartments_for_sale():
         publish_on_oikotie=False,
     )
     # should fail with oikotie housing companies
-    elastic_apartment_2 = ApartmentMinimalFactory.build(
+    elastic_apartment_2 = ApartmentMinimalFactory.create(
         project_estate_agent_email="",
         apartment_state_of_sale=ApartmentStateOfSale.FOR_SALE,
         _language="fi",
@@ -135,7 +135,7 @@ def invalid_data_elastic_apartments_for_sale():
         publish_on_oikotie=True,
     )
     # should fail with oikotie apartments and housing companies
-    elastic_apartment_3 = ApartmentMinimalFactory.build(
+    elastic_apartment_3 = ApartmentMinimalFactory.create(
         project_new_development_status="some text",
         project_estate_agent_email="",
         apartment_state_of_sale=ApartmentStateOfSale.FOR_SALE,
@@ -149,8 +149,7 @@ def invalid_data_elastic_apartments_for_sale():
         elastic_apartment_2,
         elastic_apartment_3,
     ]
-    for item in apartments:
-        item.save(refresh="wait_for")
+
     yield apartments
 
     for item in apartments:

--- a/connections/tests/conftest.py
+++ b/connections/tests/conftest.py
@@ -112,7 +112,7 @@ def test_folder():
 
 
 @fixture
-def invalid_data_elastic_apartments_for_sale():
+def invalid_data_elastic_apartments_for_sale(elastic_apartments):
     # etuovi (and oikotie apartment) invalid data is in project_holding_type
     # oikotie apartment invalid data data is in project_new_development_status
     # oikotie housing company invalid data is in project_estate_agent_email
@@ -152,5 +152,5 @@ def invalid_data_elastic_apartments_for_sale():
 
     yield apartments
 
-    for item in apartments:
-        item.delete(refresh="wait_for")
+    for apartment in apartments:
+        apartment.delete(refresh=True)

--- a/connections/tests/factories.py
+++ b/connections/tests/factories.py
@@ -1,9 +1,9 @@
+import factory
 import string
-import uuid
 from factory import Faker, fuzzy
 from typing import List
 
-from apartment.tests.factories import ApartmentDocumentTest, ElasticFactory, get_uuid
+from apartment.tests.factories import ApartmentDocumentTest, ElasticFactory
 from connections.enums import ApartmentStateOfSale, ProjectStateOfSale
 from connections.oikotie.field_mapper import NEW_DEVELOPMENT_STATUS_MAPPING
 
@@ -15,8 +15,8 @@ class ApartmentMinimalFactory(ElasticFactory):
     _language = fuzzy.FuzzyChoice(["en", "fi"])
     project_id = fuzzy.FuzzyInteger(0, 999)
     # mandatory fields for vendors:
-    project_uuid = str(uuid.uuid4())
-    uuid = fuzzy.FuzzyAttribute(get_uuid)
+    project_uuid = factory.Faker("uuid4")
+    uuid = factory.Faker("uuid4")
     project_ownership_type = fuzzy.FuzzyChoice(["Haso", "Hitas", "Puolihitas"])
     project_housing_company = fuzzy.FuzzyText()
     project_holding_type = "RIGHT_OF_RESIDENCE_APARTMENT"

--- a/connections/tests/test_api.py
+++ b/connections/tests/test_api.py
@@ -10,10 +10,12 @@ from connections.tests.utils import (
 )
 
 
-@pytest.mark.usefixtures("client", "elastic_apartments")
+@pytest.mark.usefixtures("client")
 @pytest.mark.django_db
 class TestConnectionsApis:
-    @pytest.mark.usefixtures("not_sending_oikotie_ftp", "not_sending_etuovi_ftp")
+    @pytest.mark.usefixtures(
+        "not_sending_oikotie_ftp", "not_sending_etuovi_ftp", "elastic_apartments"
+    )
     def test_get_mapped_apartments(self, api_client):
         expected = get_elastic_apartments_for_sale_published_uuids()
 
@@ -24,7 +26,9 @@ class TestConnectionsApis:
 
         assert response.data == expected
 
-    @pytest.mark.usefixtures("not_sending_oikotie_ftp", "not_sending_etuovi_ftp")
+    @pytest.mark.usefixtures(
+        "not_sending_oikotie_ftp", "not_sending_etuovi_ftp", "elastic_apartments"
+    )
     def test_get_new_published_apartments(self, api_client):
         expected = get_elastic_apartments_for_sale_published_uuids()
 
@@ -51,7 +55,9 @@ class TestConnectionsApis:
         # new apartments are 3 from not published anywhere
         assert len(response_new.data) - len(response.data) == 3
 
-    @pytest.mark.usefixtures("not_sending_oikotie_ftp", "not_sending_etuovi_ftp")
+    @pytest.mark.usefixtures(
+        "not_sending_oikotie_ftp", "not_sending_etuovi_ftp", "elastic_apartments"
+    )
     def test_apartments_for_sale_need_FOR_SALE_flag(self, api_client):
         expected = get_elastic_apartments_not_for_sale()
 
@@ -62,7 +68,9 @@ class TestConnectionsApis:
 
         assert set(expected) not in set(response.data)
 
-    @pytest.mark.usefixtures("not_sending_oikotie_ftp", "not_sending_etuovi_ftp")
+    @pytest.mark.usefixtures(
+        "not_sending_oikotie_ftp", "not_sending_etuovi_ftp", "elastic_apartments"
+    )
     def test_no_mapped_apartments(self, api_client):
         """
         if no apartments are mapped should return empty list

--- a/connections/tests/test_etuovi.py
+++ b/connections/tests/test_etuovi.py
@@ -48,7 +48,7 @@ class TestEtuoviMapper:
         raise Exception("Missing project_building_type should have thrown a ValueError")
 
 
-@pytest.mark.usefixtures("client", "elastic_apartments")
+@pytest.mark.usefixtures("client")
 @pytest.mark.django_db
 class TestApartmentFetchingFromElasticAndMapping:
     """
@@ -56,6 +56,7 @@ class TestApartmentFetchingFromElasticAndMapping:
     file and saving correctly mapped apartments to database.
     """
 
+    @pytest.mark.usefixtures("elastic_apartments")
     def test_apartments_for_sale_fetched_to_XML(self):
         expected = get_elastic_apartments_for_sale_published_on_etuovi_uuids()
         items = fetch_apartments_for_sale()
@@ -86,7 +87,7 @@ class TestApartmentFetchingFromElasticAndMapping:
         assert elastic_etuovi != apartments
         assert expected == apartments
 
-    @pytest.mark.usefixtures("not_sending_etuovi_ftp")
+    @pytest.mark.usefixtures("not_sending_etuovi_ftp", "elastic_apartments")
     def test_mapped_etuovi_saved_to_database_with_publish_updated(self):
         call_command("send_etuovi_xml_file")
         etuovi_mapped = MappedApartment.objects.filter(mapped_etuovi=True).values_list(
@@ -125,6 +126,7 @@ class TestApartmentFetchingFromElasticAndMapping:
 
         assert oikotie_mapped == 0
 
+    @pytest.mark.usefixtures("elastic_apartments")
     def test_no_apartments_for_sale_not_creating_file_and_updating_database(self):
         call_command("send_etuovi_xml_file")
         expected = list(

--- a/connections/tests/test_oikotie.py
+++ b/connections/tests/test_oikotie.py
@@ -279,13 +279,14 @@ class TestOikotieMapper:
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("client", "elastic_apartments")
+@pytest.mark.usefixtures("client")
 class TestApartmentFetchingFromElasticAndMapping:
     """
     Tests for fetching apartments from elasticsearch with Oikotie mapper, creating XML
     files and saving correctly mapped apartments to database.
     """
 
+    @pytest.mark.usefixtures("elastic_apartments")
     def test_apartments_for_sale_fetched_to_XML(self):
 
         expected_ap = get_elastic_apartments_for_sale_published_on_oikotie_uuids()
@@ -330,7 +331,7 @@ class TestApartmentFetchingFromElasticAndMapping:
         assert elastic_oikotie_ap != apartments
         assert expected_ap == apartments
 
-    @pytest.mark.usefixtures("not_sending_oikotie_ftp")
+    @pytest.mark.usefixtures("not_sending_oikotie_ftp", "elastic_apartments")
     def test_mapped_oikotie_saved_to_database_with_publish_updated(self):
         call_command("send_oikotie_xml_file")
         oikotie_mapped = MappedApartment.objects.filter(
@@ -374,6 +375,7 @@ class TestApartmentFetchingFromElasticAndMapping:
         # return data to original
         unpublish_elastic_oikotie_apartments(not_published)
 
+    @pytest.mark.usefixtures("elastic_apartments")
     def test_no_apartments_for_sale(self):
         """
         Test that after apartments are sold database is updated and
@@ -404,13 +406,13 @@ class TestApartmentFetchingFromElasticAndMapping:
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("client", "elastic_apartments")
+@pytest.mark.usefixtures("client")
 class TestSendOikotieXMLFileCommand:
     """
     Tests for django command send_oikotie_xml_file with different parameters
     """
 
-    @pytest.mark.usefixtures("not_sending_oikotie_ftp")
+    @pytest.mark.usefixtures("not_sending_oikotie_ftp", "elastic_apartments")
     def test_send_oikotie_xml_file_only_create_files(self, test_folder):
         """
         Test that after calling send_oikotie_xml_file --only_create_files
@@ -430,7 +432,7 @@ class TestSendOikotieXMLFileCommand:
         for f in files:
             os.remove(os.path.join(test_folder, f))
 
-    @pytest.mark.usefixtures("not_sending_oikotie_ftp")
+    @pytest.mark.usefixtures("not_sending_oikotie_ftp", "elastic_apartments")
     def test_send_oikotie_xml_file_send_only_type_1(self, test_folder):
         """
         Test that after calling send_oikotie_xml_file --send_only_type 1
@@ -448,7 +450,7 @@ class TestSendOikotieXMLFileCommand:
         for f in files:
             os.remove(os.path.join(test_folder, f))
 
-    @pytest.mark.usefixtures("not_sending_oikotie_ftp")
+    @pytest.mark.usefixtures("not_sending_oikotie_ftp", "elastic_apartments")
     def test_send_oikotie_xml_file_send_only_type_2(self, test_folder):
         """
         Test that after calling send_oikotie_xml_file --send_only_type 2
@@ -497,7 +499,7 @@ class TestSendOikotieXMLFileCommand:
         for f in files:
             os.remove(os.path.join(test_folder, f))
 
-    @pytest.mark.usefixtures("not_sending_oikotie_ftp")
+    @pytest.mark.usefixtures("not_sending_oikotie_ftp", "elastic_apartments")
     def test_send_oikotie_xml_no_arguments(self, test_folder):
         """
         Test that after calling send_oikotie_xml_file without arguments
@@ -522,7 +524,7 @@ class TestSendOikotieXMLFileCommand:
         for f in files:
             os.remove(os.path.join(test_folder, f))
 
-    @pytest.mark.usefixtures("not_sending_oikotie_ftp")
+    @pytest.mark.usefixtures("not_sending_oikotie_ftp", "elastic_apartments")
     def test_send_oikotie_xml_no_apartments(self, test_folder):
         """
         Test that after calling send_oikotie_xml_file with no apartments to map,

--- a/connections/tests/utils.py
+++ b/connections/tests/utils.py
@@ -7,8 +7,8 @@ from connections.enums import ApartmentStateOfSale
 
 
 def make_apartments_sold_in_elastic() -> None:
-    s_obj = ApartmentDocument.search().query(
-        "match", apartment_state_of_sale=ApartmentStateOfSale.FOR_SALE
+    s_obj = ApartmentDocument.search().filter(
+        "term", apartment_state_of_sale__keyword=ApartmentStateOfSale.FOR_SALE
     )
     s_obj.delete()
 
@@ -24,12 +24,12 @@ def get_elastic_apartments_for_sale_published_on_etuovi_uuids(
     """
     s_obj = (
         ApartmentDocument.search()
-        .query("match", _language="fi")
-        .query("match", apartment_state_of_sale=ApartmentStateOfSale.FOR_SALE)
-        .query("match", publish_on_etuovi=True)
+        .filter("term", _language__keyword="fi")
+        .filter("term", apartment_state_of_sale__keyword=ApartmentStateOfSale.FOR_SALE)
+        .filter("term", publish_on_etuovi=True)
     )
     if only_etuovi_published:
-        s_obj = s_obj.query("match", publish_on_oikotie=False)
+        s_obj = s_obj.filter("term", publish_on_oikotie=False)
 
     s_obj.execute()
     scan = s_obj.scan()
@@ -48,12 +48,12 @@ def get_elastic_apartments_for_sale_published_on_oikotie_uuids(
     """
     s_obj = (
         ApartmentDocument.search()
-        .query("match", _language="fi")
-        .query("match", apartment_state_of_sale=ApartmentStateOfSale.FOR_SALE)
-        .query("match", publish_on_oikotie=True)
+        .filter("term", _language__keyword="fi")
+        .filter("term", apartment_state_of_sale__keyword=ApartmentStateOfSale.FOR_SALE)
+        .filter("term", publish_on_oikotie=True)
     )
     if only_oikotie_published:
-        s_obj = s_obj.query("match", publish_on_etuovi=False)
+        s_obj = s_obj.filter("term", publish_on_etuovi=False)
 
     s_obj.execute()
     scan = s_obj.scan()
@@ -69,10 +69,10 @@ def get_elastic_apartments_for_sale_published_uuids() -> list:
     """
     s_obj = (
         ApartmentDocument.search()
-        .query("match", _language="fi")
-        .query("match", apartment_state_of_sale=ApartmentStateOfSale.FOR_SALE)
-        .query("match", publish_on_etuovi=True)
-        .query("match", publish_on_oikotie=True)
+        .filter("term", _language__keyword="fi")
+        .filter("term", apartment_state_of_sale__keyword=ApartmentStateOfSale.FOR_SALE)
+        .filter("term", publish_on_etuovi=True)
+        .filter("term", publish_on_oikotie=True)
     )
 
     s_obj.execute()
@@ -89,10 +89,10 @@ def get_elastic_apartments_for_sale_only_uuids() -> list:
     """
     s_obj = (
         ApartmentDocument.search()
-        .query("match", _language="fi")
-        .query("match", apartment_state_of_sale=ApartmentStateOfSale.FOR_SALE)
-        .query("match", publish_on_etuovi=False)
-        .query("match", publish_on_oikotie=False)
+        .filter("term", _language__keyword="fi")
+        .filter("term", apartment_state_of_sale__keyword=ApartmentStateOfSale.FOR_SALE)
+        .filter("term", publish_on_etuovi=False)
+        .filter("term", publish_on_oikotie=False)
     )
 
     s_obj.execute()
@@ -109,9 +109,9 @@ def get_elastic_apartments_not_for_sale():
     """
     s_obj = (
         ApartmentDocument.search()
-        .query("match", publish_on_oikotie=True)
-        .query("match", publish_on_etuovi=True)
-        .query("match", apartment_state_of_sale=ApartmentStateOfSale.RESERVED)
+        .filter("term", publish_on_oikotie=True)
+        .filter("term", publish_on_etuovi=True)
+        .filter("term", apartment_state_of_sale__keyword=ApartmentStateOfSale.RESERVED)
     )
     s_obj.execute()
     scan = s_obj.scan()
@@ -125,9 +125,9 @@ def get_elastic_apartments_for_sale_project_uuids() -> list:
     """Used only in oikotie tests for fetching expected housing companies"""
     s_obj = (
         ApartmentDocument.search()
-        .query("match", _language="fi")
-        .query("match", apartment_state_of_sale=ApartmentStateOfSale.FOR_SALE)
-        .query("match", publish_on_oikotie=True)
+        .filter("term", _language__keyword="fi")
+        .filter("term", apartment_state_of_sale__keyword=ApartmentStateOfSale.FOR_SALE)
+        .filter("term", publish_on_oikotie=True)
     )
     s_obj.execute()
     scan = s_obj.scan()
@@ -146,30 +146,30 @@ def publish_elastic_apartments(
     """
     u_obj = UpdateByQuery(
         index=settings.APARTMENT_INDEX_NAME,
-    ).query("multi_match", query=" ".join(uuids), fields=["uuid"])
+    ).filter("terms", uuid__keyword=uuids)
 
     if publish_to_etuovi and publish_to_oikotie:
         u_obj = u_obj.script(
-            source="ctx._source.publish_on_oikotie = true; "
-            "ctx._source.publish_on_etuovi = true"
+            source="ctx._source.publish_on_oikotie=true; "
+            "ctx._source.publish_on_etuovi=true"
         )
     elif publish_to_oikotie:
-        u_obj = u_obj.script(source="ctx._source.publish_on_oikotie = true")
+        u_obj = u_obj.script(source="ctx._source.publish_on_oikotie=true")
     elif publish_to_etuovi:
-        u_obj = u_obj.script(source="ctx._source.publish_on_etuovi = true")
+        u_obj = u_obj.script(source="ctx._source.publish_on_etuovi=true")
     u_obj.execute()
 
     get_connection().indices.refresh(index=settings.APARTMENT_INDEX_NAME)
 
     s_obj = (
         Search()
-        .query("match", _language="fi")
-        .query("match", apartment_state_of_sale=ApartmentStateOfSale.FOR_SALE)
+        .filter("term", _language__keyword="fi")
+        .filter("term", apartment_state_of_sale__keyword=ApartmentStateOfSale.FOR_SALE)
     )
     if publish_to_oikotie:
-        s_obj = s_obj.query("match", publish_on_oikotie=publish_to_oikotie)
+        s_obj = s_obj.filter("term", publish_on_oikotie=publish_to_oikotie)
     if publish_to_etuovi:
-        s_obj = s_obj.query("match", publish_on_etuovi=publish_to_etuovi)
+        s_obj = s_obj.filter("term", publish_on_etuovi=publish_to_etuovi)
     scan = s_obj.scan()
     uuids = []
 
@@ -185,9 +185,9 @@ def unpublish_elastic_oikotie_apartments(uuids: list) -> list:
     """
     u_obj = UpdateByQuery(
         index=settings.APARTMENT_INDEX_NAME,
-    ).query("multi_match", query=" ".join(uuids), fields=["uuid"])
+    ).filter("terms", uuid__keyword=uuids)
 
-    u_obj = u_obj.script(source="ctx._source.publish_on_oikotie = false")
+    u_obj = u_obj.script(source="ctx._source.publish_on_oikotie=false")
     u_obj.execute()
 
     get_connection().indices.refresh(index=settings.APARTMENT_INDEX_NAME)

--- a/connections/tests/utils.py
+++ b/connections/tests/utils.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from elasticsearch_dsl import Search, UpdateByQuery
-from time import sleep
+from elasticsearch_dsl.connections import get_connection
 
 from apartment.elastic.documents import ApartmentDocument
 from connections.enums import ApartmentStateOfSale
@@ -11,7 +11,8 @@ def make_apartments_sold_in_elastic() -> None:
         "match", apartment_state_of_sale=ApartmentStateOfSale.FOR_SALE
     )
     s_obj.delete()
-    sleep(3)
+
+    get_connection().indices.refresh(index=settings.APARTMENT_INDEX_NAME)
 
 
 def get_elastic_apartments_for_sale_published_on_etuovi_uuids(
@@ -157,7 +158,8 @@ def publish_elastic_apartments(
     elif publish_to_etuovi:
         u_obj = u_obj.script(source="ctx._source.publish_on_etuovi = true")
     u_obj.execute()
-    sleep(3)
+
+    get_connection().indices.refresh(index=settings.APARTMENT_INDEX_NAME)
 
     s_obj = (
         Search()
@@ -187,4 +189,5 @@ def unpublish_elastic_oikotie_apartments(uuids: list) -> list:
 
     u_obj = u_obj.script(source="ctx._source.publish_on_oikotie = false")
     u_obj.execute()
-    sleep(3)
+
+    get_connection().indices.refresh(index=settings.APARTMENT_INDEX_NAME)


### PR DESCRIPTION
* Refactor, simplify and fix the usage of elasticsearch in tests
* Add SonarCloud properties file which excludes paths and set the use of python 3
* And fixed other issues what has appeared on the fixing and refactoring

This is now 5 times attempted on the CI test without any errors.