### PR TITLE
Add project's apartment reservation list endpoint

### DIFF
--- a/apartment/tests/factories.py
+++ b/apartment/tests/factories.py
@@ -18,6 +18,7 @@ class ProjectFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Project
 
+    uuid = factory.Faker("uuid4")
     street_address = Faker("street_address")
 
     @factory.post_generation

--- a/application_form/api/serializers.py
+++ b/application_form/api/serializers.py
@@ -4,8 +4,8 @@ from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 from rest_framework.fields import CharField, IntegerField, UUIDField
 
-from application_form.enums import ApplicationType
-from application_form.models import Applicant, Application
+from application_form.enums import ApartmentReservationState, ApplicationType
+from application_form.models import ApartmentReservation, Applicant, Application
 from application_form.services.application import create_application
 from application_form.validators import SSNSuffixValidator
 
@@ -90,3 +90,20 @@ class ApplicationSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         validated_data["profile"] = self.context["request"].user.profile
         return create_application(validated_data)
+
+
+class ApartmentReservationSerializer(serializers.ModelSerializer):
+    apartment_uuid = UUIDField(source="apartment.uuid")
+    lottery_position = IntegerField(
+        source="application_apartment.lotteryeventresult.result_position"
+    )
+    state = EnumField(ApartmentReservationState)
+
+    class Meta:
+        model = ApartmentReservation
+        fields = [
+            "apartment_uuid",
+            "lottery_position",
+            "queue_position",
+            "state",
+        ]

--- a/application_form/tests/api/test_project_reservation_view.py
+++ b/application_form/tests/api/test_project_reservation_view.py
@@ -1,0 +1,79 @@
+import pytest
+from django.urls import reverse
+
+from apartment.tests.factories import ApartmentFactory, ProjectFactory
+from application_form.tests.factories import (
+    ApartmentReservationFactory,
+    ApplicationApartmentFactory,
+    ApplicationFactory,
+    LotteryEventFactory,
+    LotteryEventResultFactory,
+)
+from users.tests.factories import ProfileFactory
+from users.tests.utils import _create_token
+
+
+@pytest.mark.django_db
+def test_list_project_reservations_get(api_client):
+    """
+    Test that the API endpoint returns the project's reservations
+    by the profile id and project UUID.
+    """
+    apartment_reservation_count = 5
+    profile = ProfileFactory()
+    project = ProjectFactory()
+    apartments = ApartmentFactory.create_batch(
+        apartment_reservation_count, project=project
+    )
+    application = ApplicationFactory(profile=profile)
+    for apartment in apartments:
+        application_apartment = ApplicationApartmentFactory(
+            apartment=apartment, application=application
+        )
+        ApartmentReservationFactory(
+            apartment=apartment, application_apartment=application_apartment
+        )
+        event = LotteryEventFactory(apartment=apartment)
+        LotteryEventResultFactory(
+            event=event, application_apartment=application_apartment
+        )
+
+    api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {_create_token(profile)}")
+    data = {"project_uuid": project.uuid}
+    response = api_client.get(
+        reverse("application_form:list_project_reservations", kwargs=data),
+        format="json",
+    )
+    assert response.status_code == 200
+    assert len(response.data) == apartment_reservation_count
+
+
+@pytest.mark.django_db
+def test_list_project_reservations_get_without_lottery_data(api_client):
+    """
+    Test that the project's reservations will be returned correctly
+    if the lottery is not yet performed.
+    """
+    apartment_reservation_count = 5
+    profile = ProfileFactory()
+    project = ProjectFactory()
+    apartments = ApartmentFactory.create_batch(5, project=project)
+    application = ApplicationFactory(profile=profile)
+    for apartment in apartments:
+        application_apartment = ApplicationApartmentFactory(
+            apartment=apartment, application=application
+        )
+        ApartmentReservationFactory(
+            apartment=apartment, application_apartment=application_apartment
+        )
+
+    api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {_create_token(profile)}")
+    data = {"project_uuid": project.uuid}
+    response = api_client.get(
+        reverse("application_form:list_project_reservations", kwargs=data),
+        format="json",
+    )
+    assert response.status_code == 200
+    assert len(response.data) == apartment_reservation_count
+    for item in response.data:
+        assert item["lottery_position"] is None

--- a/application_form/tests/factories.py
+++ b/application_form/tests/factories.py
@@ -4,8 +4,15 @@ from factory import Faker, fuzzy, LazyAttribute
 from typing import List
 
 from apartment.tests.factories import ApartmentFactory
-from application_form.enums import ApplicationType
-from application_form.models import Applicant, Application, ApplicationApartment
+from application_form.enums import ApartmentReservationState, ApplicationType
+from application_form.models import (
+    ApartmentReservation,
+    Applicant,
+    Application,
+    ApplicationApartment,
+    LotteryEvent,
+    LotteryEventResult,
+)
 from application_form.services.application import _calculate_age
 from users.tests.factories import ProfileFactory
 
@@ -72,7 +79,7 @@ class ApplicationApartmentFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = ApplicationApartment
 
-    priority_number = 1
+    priority_number = fuzzy.FuzzyInteger(1, 5)
     apartment = factory.SubFactory(ApartmentFactory)
     application = factory.SubFactory(ApplicationWithApplicantsFactory)
 
@@ -90,3 +97,29 @@ class ApplicationApartmentFactory(factory.django.DjangoModelFactory):
             )
             apartments_application.append(apartment_application)
         return apartments_application
+
+
+class ApartmentReservationFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = ApartmentReservation
+
+    apartment = factory.SubFactory(ApartmentFactory)
+    queue_position = fuzzy.FuzzyInteger(1)
+    application_apartment = factory.SubFactory(ApplicationApartmentFactory)
+    state = fuzzy.FuzzyChoice(list(ApartmentReservationState))
+
+
+class LotteryEventFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = LotteryEvent
+
+    apartment = factory.SubFactory(ApartmentFactory)
+
+
+class LotteryEventResultFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = LotteryEventResult
+
+    event = factory.SubFactory(LotteryEventFactory)
+    application_apartment = factory.SubFactory(ApplicationApartmentFactory)
+    result_position = fuzzy.FuzzyInteger(1)

--- a/application_form/urls.py
+++ b/application_form/urls.py
@@ -5,13 +5,25 @@ from application_form.api.sales.views import (
     execute_lottery_for_project,
     SalesApplicationViewSet,
 )
-from application_form.api.views import ApplicationViewSet
+from application_form.api.views import ApplicationViewSet, ListProjectReservations
 
 router = DefaultRouter()
 router.register(r"applications", ApplicationViewSet)
 router.register(
     r"sales/applications", SalesApplicationViewSet, basename="sales-application"
 )
+
+
+# URLs for public web pages
+# URL-keyword 'me' means that the profile UUID will be retrieved from the authentication
+# data.
+public_urlpatterns = [
+    path(
+        r"profiles/me/projects/<uuid:project_uuid>/reservations",
+        ListProjectReservations.as_view(),
+        name="list_project_reservations",
+    )
+]
 
 urlpatterns = [
     path(
@@ -21,3 +33,4 @@ urlpatterns = [
     ),
     path("", include(router.urls)),
 ]
+urlpatterns += public_urlpatterns


### PR DESCRIPTION
This endpoint is made for a user profile that returns the user's apartment reservations of a project they have applied for.

The URL path is `profiles/me/projects/<uuid:project_uuid>/reservations`. The information of the user profile has been separated under the `profiles`.

The API is inherited from the `GenericAPIView` that we get also the response information to Swagger.