### PR TITLE
Improve HASO in lottery API endpoint

### DIFF
--- a/application_form/services/lottery/hitas.py
+++ b/application_form/services/lottery/hitas.py
@@ -3,8 +3,6 @@ from django.db import transaction
 from django.db.models import QuerySet
 
 from apartment.models import Apartment, Project
-from application_form.exceptions import ProjectDoesNotHaveApplicationsException
-from application_form.models import Application
 from application_form.services.application import _reserve_apartments
 from application_form.services.lottery.utils import _save_application_order
 
@@ -21,10 +19,6 @@ def distribute_hitas_apartments(project: Project) -> None:
     each, and marks the winning application as reserved. Before declaring a winner, the
     state of the apartment queue will be persisted to the database.
     """
-
-    application_count = Application.objects.filter(apartments__project=project).count()
-    if application_count == 0:
-        raise ProjectDoesNotHaveApplicationsException()
 
     apartments = project.apartments.all()
 

--- a/application_form/services/lottery/machine.py
+++ b/application_form/services/lottery/machine.py
@@ -2,11 +2,17 @@ from django.utils.translation import ugettext_lazy as _
 
 from apartment.enums import OwnershipType
 from apartment.models import Project
+from application_form.exceptions import ProjectDoesNotHaveApplicationsException
+from application_form.models import Application
 from application_form.services.lottery.haso import distribute_haso_apartments
 from application_form.services.lottery.hitas import distribute_hitas_apartments
 
 
 def distribute_apartments(project: Project) -> None:
+    application_count = Application.objects.filter(apartments__project=project).count()
+    if application_count == 0:
+        raise ProjectDoesNotHaveApplicationsException()
+
     if project.ownership_type is OwnershipType.HASO:
         distribute_haso_apartments(project)
     elif project.ownership_type in [OwnershipType.HITAS, OwnershipType.HALF_HITAS]:

--- a/application_form/tests/test_lottery_api.py
+++ b/application_form/tests/test_lottery_api.py
@@ -80,3 +80,36 @@ def test_execute_hitas_lottery_for_project_post_without_applications(api_client)
         reverse("application_form:execute_lottery_for_project"), data, format="json"
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("elastic_apartments")
+def test_execute_haso_lottery_for_project_post(api_client):
+    profile = SalespersonProfileFactory()
+    api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {_create_token(profile)}")
+
+    apartment = ApartmentFactory(project__ownership_type=OwnershipType.HASO)
+    app = ApplicationFactory(type=ApplicationType.HASO)
+    app.application_apartments.create(apartment=apartment, priority_number=0)
+    add_application_to_queues(app)
+
+    data = {"project_uuid": apartment.project.uuid}
+    response = api_client.post(
+        reverse("application_form:execute_lottery_for_project"), data, format="json"
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("elastic_apartments")
+def test_execute_haso_lottery_for_project_post_without_applications(api_client):
+    profile = SalespersonProfileFactory()
+    api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {_create_token(profile)}")
+
+    apartment = ApartmentFactory(project__ownership_type=OwnershipType.HASO)
+
+    data = {"project_uuid": apartment.project.uuid}
+    response = api_client.post(
+        reverse("application_form:execute_lottery_for_project"), data, format="json"
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/application_form/tests/test_lottery_api.py
+++ b/application_form/tests/test_lottery_api.py
@@ -13,24 +13,6 @@ from users.tests.utils import _create_token
 
 @pytest.mark.django_db
 @pytest.mark.usefixtures("elastic_apartments")
-def test_execute_hitas_lottery_for_project_post(api_client):
-    profile = SalespersonProfileFactory()
-    api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {_create_token(profile)}")
-
-    apartment = ApartmentFactory(project__ownership_type=OwnershipType.HITAS)
-    app = ApplicationFactory(type=ApplicationType.HITAS)
-    app.application_apartments.create(apartment=apartment, priority_number=0)
-    add_application_to_queues(app)
-
-    data = {"project_uuid": apartment.project.uuid}
-    response = api_client.post(
-        reverse("application_form:execute_lottery_for_project"), data, format="json"
-    )
-    assert response.status_code == status.HTTP_200_OK
-
-
-@pytest.mark.django_db
-@pytest.mark.usefixtures("elastic_apartments")
 def test_execute_lottery_for_project_post_without_project_uuid(api_client):
     profile = SalespersonProfileFactory()
     api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {_create_token(profile)}")
@@ -69,7 +51,25 @@ def test_execute_lottery_for_project_post_not_found(api_client):
 
 @pytest.mark.django_db
 @pytest.mark.usefixtures("elastic_apartments")
-def test_execute_lottery_for_project_post_without_applications(api_client):
+def test_execute_hitas_lottery_for_project_post(api_client):
+    profile = SalespersonProfileFactory()
+    api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {_create_token(profile)}")
+
+    apartment = ApartmentFactory(project__ownership_type=OwnershipType.HITAS)
+    app = ApplicationFactory(type=ApplicationType.HITAS)
+    app.application_apartments.create(apartment=apartment, priority_number=0)
+    add_application_to_queues(app)
+
+    data = {"project_uuid": apartment.project.uuid}
+    response = api_client.post(
+        reverse("application_form:execute_lottery_for_project"), data, format="json"
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("elastic_apartments")
+def test_execute_hitas_lottery_for_project_post_without_applications(api_client):
     profile = SalespersonProfileFactory()
     api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {_create_token(profile)}")
 


### PR DESCRIPTION
* Move the checkup of the application count that it also covers HASO apartments. Before the lottery can be executed, the project needs to have applications.
* Add HASO tests for the lottery API endpoint