### PR TITLE
Add project application time validation to lottery

### DIFF
--- a/application_form/api/sales/views.py
+++ b/application_form/api/sales/views.py
@@ -16,6 +16,9 @@ from application_form.api.sales.serializers import (
 )
 from application_form.api.views import ApplicationViewSet
 from application_form.exceptions import ProjectDoesNotHaveApplicationsException
+from application_form.services.lottery.exceptions import (
+    ApplicationTimeNotFinishedException,
+)
 from application_form.services.lottery.machine import distribute_apartments
 from users.permissions import IsSalesperson
 
@@ -42,6 +45,8 @@ def execute_lottery_for_project(request):
         distribute_apartments(project_uuid)
     except ProjectDoesNotHaveApplicationsException as ex:
         raise ValidationError(detail="Project does not have applications.") from ex
+    except ApplicationTimeNotFinishedException as ex:
+        raise ValidationError(detail=str(ex)) from ex
 
     return Response({"status": "success"}, status=status.HTTP_200_OK)
 

--- a/application_form/services/lottery/exceptions.py
+++ b/application_form/services/lottery/exceptions.py
@@ -1,0 +1,14 @@
+"""
+Lottery exception classes.
+"""
+
+
+class ApplicationTimeNotFinishedException(Exception):
+    """
+    Raises when the project's application time is not finished.
+    """
+
+    def __init__(
+        self, msg="Project's application time is not finished.", *args, **kwargs
+    ):
+        super().__init__(msg, *args, **kwargs)

--- a/application_form/services/lottery/haso.py
+++ b/application_form/services/lottery/haso.py
@@ -5,7 +5,7 @@ from application_form.services.application import _reserve_haso_apartment
 from application_form.services.lottery.utils import _save_application_order
 
 
-def distribute_haso_apartments(project_uuid: uuid.UUID) -> None:
+def _distribute_haso_apartments(project_uuid: uuid.UUID) -> None:
     """
     Declares a winner for each apartment in the project.
 

--- a/application_form/services/lottery/hitas.py
+++ b/application_form/services/lottery/hitas.py
@@ -13,7 +13,7 @@ from application_form.services.lottery.utils import _save_application_order
 _PRIORITIZE_CHILDREN_ROOM_THRESHOLD = 3
 
 
-def distribute_hitas_apartments(project_uuid: uuid.UUID) -> None:
+def _distribute_hitas_apartments(project_uuid: uuid.UUID) -> None:
     """
     Declares a winner for each apartment in the project.
 

--- a/application_form/services/lottery/machine.py
+++ b/application_form/services/lottery/machine.py
@@ -5,8 +5,8 @@ from apartment.elastic.queries import get_apartment_uuids, get_projects
 from apartment.enums import OwnershipType
 from application_form.exceptions import ProjectDoesNotHaveApplicationsException
 from application_form.models import Application
-from application_form.services.lottery.haso import distribute_haso_apartments
-from application_form.services.lottery.hitas import distribute_hitas_apartments
+from application_form.services.lottery.haso import _distribute_haso_apartments
+from application_form.services.lottery.hitas import _distribute_hitas_apartments
 
 
 def distribute_apartments(project_uuid: uuid.UUID) -> None:
@@ -19,12 +19,12 @@ def distribute_apartments(project_uuid: uuid.UUID) -> None:
 
     project = get_projects(project_uuid)[0]
     if project.project_ownership_type.lower() == OwnershipType.HASO.value:
-        distribute_haso_apartments(project_uuid)
+        _distribute_haso_apartments(project_uuid)
     elif project.project_ownership_type.lower() in [
         OwnershipType.HITAS.value,
         OwnershipType.HALF_HITAS.value,
     ]:
-        distribute_hitas_apartments(project_uuid)
+        _distribute_hitas_apartments(project_uuid)
     else:
         raise NotImplementedError(
             _(

--- a/application_form/services/lottery/machine.py
+++ b/application_form/services/lottery/machine.py
@@ -1,21 +1,15 @@
 import uuid
 from django.utils.translation import ugettext_lazy as _
 
-from apartment.elastic.queries import get_apartment_uuids, get_projects
+from apartment.elastic.queries import get_projects
 from apartment.enums import OwnershipType
-from application_form.exceptions import ProjectDoesNotHaveApplicationsException
-from application_form.models import Application
 from application_form.services.lottery.haso import _distribute_haso_apartments
 from application_form.services.lottery.hitas import _distribute_hitas_apartments
+from application_form.services.lottery.utils import _validate_project_has_applications
 
 
 def distribute_apartments(project_uuid: uuid.UUID) -> None:
-    apartment_uuids = get_apartment_uuids(project_uuid)
-    application_count = Application.objects.filter(
-        application_apartments__apartment_uuid__in=apartment_uuids
-    ).count()
-    if application_count == 0:
-        raise ProjectDoesNotHaveApplicationsException()
+    _validate_project_has_applications(project_uuid)
 
     project = get_projects(project_uuid)[0]
     if project.project_ownership_type.lower() == OwnershipType.HASO.value:

--- a/application_form/services/lottery/machine.py
+++ b/application_form/services/lottery/machine.py
@@ -5,11 +5,15 @@ from apartment.elastic.queries import get_projects
 from apartment.enums import OwnershipType
 from application_form.services.lottery.haso import _distribute_haso_apartments
 from application_form.services.lottery.hitas import _distribute_hitas_apartments
-from application_form.services.lottery.utils import _validate_project_has_applications
+from application_form.services.lottery.utils import (
+    _validate_project_application_time_has_finished,
+    _validate_project_has_applications,
+)
 
 
 def distribute_apartments(project_uuid: uuid.UUID) -> None:
     _validate_project_has_applications(project_uuid)
+    _validate_project_application_time_has_finished(project_uuid)
 
     project = get_projects(project_uuid)[0]
     if project.project_ownership_type.lower() == OwnershipType.HASO.value:

--- a/application_form/services/lottery/utils.py
+++ b/application_form/services/lottery/utils.py
@@ -1,6 +1,8 @@
 import uuid
 
-from application_form.models import ApartmentReservation, LotteryEvent
+from apartment.elastic.queries import get_apartment_uuids
+from application_form.exceptions import ProjectDoesNotHaveApplicationsException
+from application_form.models import ApartmentReservation, Application, LotteryEvent
 
 
 def _save_application_order(apartment_uuid: uuid.UUID) -> None:
@@ -21,3 +23,12 @@ def _save_application_order(apartment_uuid: uuid.UUID) -> None:
             application_apartment=apartment_reservation.application_apartment,
             result_position=apartment_reservation.queue_position,
         )
+
+
+def _validate_project_has_applications(project_uuid: uuid.UUID):
+    apartment_uuids = get_apartment_uuids(project_uuid)
+    application_count = Application.objects.filter(
+        application_apartments__apartment_uuid__in=apartment_uuids
+    ).count()
+    if application_count == 0:
+        raise ProjectDoesNotHaveApplicationsException()

--- a/application_form/services/lottery/utils.py
+++ b/application_form/services/lottery/utils.py
@@ -1,8 +1,12 @@
 import uuid
+from django.utils import timezone
 
-from apartment.elastic.queries import get_apartment_uuids
+from apartment.elastic.queries import get_apartment_uuids, get_projects
 from application_form.exceptions import ProjectDoesNotHaveApplicationsException
 from application_form.models import ApartmentReservation, Application, LotteryEvent
+from application_form.services.lottery.exceptions import (
+    ApplicationTimeNotFinishedException,
+)
 
 
 def _save_application_order(apartment_uuid: uuid.UUID) -> None:
@@ -32,3 +36,12 @@ def _validate_project_has_applications(project_uuid: uuid.UUID):
     ).count()
     if application_count == 0:
         raise ProjectDoesNotHaveApplicationsException()
+
+
+def _validate_project_application_time_has_finished(project_uuid: uuid.UUID):
+    project = get_projects(project_uuid)[0]
+    if (
+        not project.project_application_end_time
+        or project.project_application_end_time >= timezone.now()
+    ):
+        raise ApplicationTimeNotFinishedException()

--- a/application_form/tests/conftest.py
+++ b/application_form/tests/conftest.py
@@ -1,6 +1,8 @@
 import faker.config
 import uuid
+from datetime import timedelta
 from django.conf import settings
+from django.utils import timezone
 from elasticsearch.helpers.test import get_test_client
 from elasticsearch_dsl.connections import add_connection
 from factory.faker import faker
@@ -181,6 +183,35 @@ def elastic_haso_project_with_5_apartments(elasticsearch):
 
     for apartment in apartments:
         apartment.delete(refresh=True)
+
+
+@fixture
+def elastic_project_application_time_active():
+    apartment = ApartmentDocumentFactory(
+        project_application_end_time=timezone.now() + timedelta(days=1)
+    )
+    yield apartment.project_uuid, apartment
+    apartment.delete(refresh=True)
+
+
+@fixture
+def elastic_hitas_project_application_end_time_finished(elasticsearch):
+    apartment = ApartmentDocumentFactory(
+        project_ownership_type="Hitas",
+        project_application_end_time=timezone.now() - timedelta(days=1),
+    )
+    yield apartment.project_uuid, apartment
+    apartment.delete(refresh=True)
+
+
+@fixture
+def elastic_haso_project_application_end_time_finished(elasticsearch):
+    apartment = ApartmentDocumentFactory(
+        project_ownership_type="Haso",
+        project_application_end_time=timezone.now() - timedelta(days=1),
+    )
+    yield apartment.project_uuid, apartment
+    apartment.delete(refresh=True)
 
 
 def create_application_data(

--- a/application_form/tests/test_lottery_api.py
+++ b/application_form/tests/test_lottery_api.py
@@ -52,7 +52,9 @@ def test_execute_lottery_for_project_post_fails_application_time_not_finished(
         reverse("application_form:execute_lottery_for_project"), data, format="json"
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert response.data[0] == "Project's application time is not finished."
+    assert (
+        response.json()[0]["message"] == "Project's application time is not finished."
+    )
 
 
 @pytest.mark.django_db

--- a/application_form/tests/test_lottery_api.py
+++ b/application_form/tests/test_lottery_api.py
@@ -36,6 +36,27 @@ def test_execute_lottery_for_project_post_badly_formatted_project_uuid(api_clien
 
 @pytest.mark.django_db
 @pytest.mark.usefixtures("elastic_apartments")
+def test_execute_lottery_for_project_post_fails_application_time_not_finished(
+    api_client, elastic_project_application_time_active
+):
+    project_uuid, apartment = elastic_project_application_time_active
+    profile = SalespersonProfileFactory()
+    api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {_create_token(profile)}")
+
+    app = ApplicationFactory(type=ApplicationType.HITAS)
+    app.application_apartments.create(apartment_uuid=apartment.uuid, priority_number=0)
+    add_application_to_queues(app)
+
+    data = {"project_uuid": project_uuid}
+    response = api_client.post(
+        reverse("application_form:execute_lottery_for_project"), data, format="json"
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.data[0] == "Project's application time is not finished."
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("elastic_apartments")
 def test_execute_lottery_for_project_post_not_found(api_client):
     profile = SalespersonProfileFactory()
     api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {_create_token(profile)}")
@@ -49,17 +70,14 @@ def test_execute_lottery_for_project_post_not_found(api_client):
 
 @pytest.mark.django_db
 def test_execute_hitas_lottery_for_project_post(
-    api_client, elastic_hitas_project_with_5_apartments
+    api_client, elastic_hitas_project_application_end_time_finished
 ):
     profile = SalespersonProfileFactory()
     api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {_create_token(profile)}")
-
-    project_uuid, apartments = elastic_hitas_project_with_5_apartments
+    project_uuid, apartment = elastic_hitas_project_application_end_time_finished
 
     app = ApplicationFactory(type=ApplicationType.HITAS)
-    app.application_apartments.create(
-        apartment_uuid=apartments[0].uuid, priority_number=0
-    )
+    app.application_apartments.create(apartment_uuid=apartment.uuid, priority_number=0)
     add_application_to_queues(app)
 
     data = {"project_uuid": project_uuid}
@@ -87,16 +105,14 @@ def test_execute_hitas_lottery_for_project_post_without_applications(
 
 @pytest.mark.django_db
 def test_execute_haso_lottery_for_project_post(
-    api_client, elastic_haso_project_with_5_apartments
+    api_client, elastic_haso_project_application_end_time_finished
 ):
     profile = SalespersonProfileFactory()
     api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {_create_token(profile)}")
+    project_uuid, apartment = elastic_haso_project_application_end_time_finished
 
-    project_uuid, apartments = elastic_haso_project_with_5_apartments
     app = ApplicationFactory(type=ApplicationType.HASO)
-    app.application_apartments.create(
-        apartment_uuid=apartments[0].uuid, priority_number=0
-    )
+    app.application_apartments.create(apartment_uuid=apartment.uuid, priority_number=0)
     add_application_to_queues(app)
 
     data = {"project_uuid": project_uuid}


### PR DESCRIPTION
This add application time validation to lottery execution. The lottery can be executed only after the project's application time has finished.