### PR TITLE
Fix execute lottery API endpoint temporal CSRF issue

### DIFF
--- a/application_form/api/sales/views.py
+++ b/application_form/api/sales/views.py
@@ -1,6 +1,10 @@
 from django.views.decorators.http import require_http_methods
 from rest_framework import permissions, status
-from rest_framework.decorators import api_view, permission_classes
+from rest_framework.decorators import (
+    api_view,
+    authentication_classes,
+    permission_classes,
+)
 from rest_framework.exceptions import NotFound, ValidationError
 from rest_framework.response import Response
 
@@ -17,6 +21,7 @@ from users.permissions import IsSalesperson
 
 @api_view(http_method_names=["POST"])
 @permission_classes([permissions.AllowAny])
+@authentication_classes([])
 @require_http_methods(["POST"])  # For SonarCloud
 def execute_lottery_for_project(request):
     """


### PR DESCRIPTION
Disabled authentication altogether from the execute lottery API endpoint for now. Authentication isn't actually used at the moment so this change doesn't actually change anything, but it is needed so that the endpoint won't return a CSRF error.