### PR TITLE
ASU-1262 | Disable sales application API ssn suffix validation

### DIFF
--- a/application_form/api/sales/serializers.py
+++ b/application_form/api/sales/serializers.py
@@ -1,12 +1,11 @@
 import logging
 from rest_framework import serializers
-from rest_framework.exceptions import ValidationError
 from rest_framework.fields import UUIDField
 
-from application_form import error_codes
-from application_form.api.serializers import ApplicationSerializer
-from application_form.services.application import create_application
-from application_form.validators import SSNSuffixValidator
+from application_form.api.serializers import (
+    ApplicantSerializerBase,
+    ApplicationSerializerBase,
+)
 from users.models import Profile
 
 _logger = logging.getLogger(__name__)
@@ -16,40 +15,15 @@ class ProjectUUIDSerializer(serializers.Serializer):
     project_uuid = UUIDField()
 
 
-class SalesApplicationSerializer(ApplicationSerializer):
+class SalesApplicantSerializer(ApplicantSerializerBase):
+    pass
+
+
+class SalesApplicationSerializer(ApplicationSerializerBase):
     profile = serializers.PrimaryKeyRelatedField(
         queryset=Profile.objects.all(), write_only=True
     )
+    additional_applicant = SalesApplicantSerializer(write_only=True, allow_null=True)
 
-    class Meta(ApplicationSerializer.Meta):
-        fields = [
-            "application_uuid",
-            "application_type",
-            "ssn_suffix",
-            "has_children",
-            "additional_applicant",
-            "right_of_residence",
-            "project_id",
-            "apartments",
-            "profile",
-        ]
-
-    def create(self, validated_data):
-        return create_application(validated_data)
-
-    def validate_ssn_suffix(self, value):
-        profile_uuid = self.context["request"].data["profile"]
-        applicant_profile = Profile.objects.get(id=profile_uuid)
-        date_of_birth = applicant_profile.date_of_birth
-        validator = SSNSuffixValidator(date_of_birth)
-        try:
-            validator(value)
-        except ValidationError as e:
-            message = f"""Invalid SSN suffix for the primary applicant was
-            received: {e.args[0]}"""
-            _logger.warning(message)
-            raise ValidationError(
-                detail=message,
-                code=error_codes.E1000_SSN_SUFFIX_IS_NOT_VALID,
-            )
-        return value
+    class Meta(ApplicationSerializerBase.Meta):
+        fields = ApplicationSerializerBase.Meta.fields + ("profile",)

--- a/application_form/tests/test_sales_application_api.py
+++ b/application_form/tests/test_sales_application_api.py
@@ -34,6 +34,8 @@ def test_sales_application_post(api_client, elastic_single_project_with_apartmen
     )
     data = create_application_data(customer_profile)
     data["profile"] = customer_profile.id
+    data["ssn_suffix"] = "XXXXX"  # ssn suffix should not be validated
+    data["additional_applicant"]["ssn_suffix"] = "XXXXX"
     response = api_client.post(
         reverse("application_form:sales-application-list"), data, format="json"
     )


### PR DESCRIPTION
Disabled SSN suffix validation from the sales API application endpoint. The validation is still present on the non-sales application endpoint.

The two application endpoints used serializers in a manner that made it difficult to disable the validation from just the sales one, so did also some refactoring to make it easier to customize them separately; previously `SalesApplicationSerializer` inherited directly from `ApplicationSerializer`, now they both inherit from a common base class, which contains all the common functionality.