### PR TITLE
ASU-1287 | API for generating apartment installments from installment templates

### DIFF
--- a/apartment/elastic/queries.py
+++ b/apartment/elastic/queries.py
@@ -3,14 +3,14 @@ from django.core.exceptions import ObjectDoesNotExist
 from apartment.elastic.documents import ApartmentDocument
 
 
-def get_apartment(apartment_uuid):
+def get_apartment(apartment_uuid, include_project_fields=False):
     search = ApartmentDocument.search()
 
     # Filters
     search = search.filter("term", uuid__keyword=apartment_uuid)
 
-    # Exclude project fields
-    search = search.source(excludes=["project_*"])
+    if not include_project_fields:
+        search = search.source(excludes=["project_*"])
 
     # Get item
     apartment = search.execute()[0]

--- a/application_form/api/sales/serializers.py
+++ b/application_form/api/sales/serializers.py
@@ -8,6 +8,7 @@ from application_form.api.serializers import (
     ApplicationSerializerBase,
 )
 from application_form.models import Applicant
+from invoicing.api.serializers import ApartmentInstallmentSerializer
 from users.models import Profile
 
 _logger = logging.getLogger(__name__)
@@ -63,3 +64,12 @@ class ApartmentReservationSerializer(ApartmentReservationSerializerBase):
             "has_children",
             "right_of_residence",
         )
+
+
+class RootApartmentReservationSerializer(ApartmentReservationSerializerBase):
+    installments = ApartmentInstallmentSerializer(
+        source="apartment_installments", many=True
+    )
+
+    class Meta(ApartmentReservationSerializerBase.Meta):
+        fields = ("installments",) + ApartmentReservationSerializerBase.Meta.fields

--- a/application_form/api/serializers.py
+++ b/application_form/api/serializers.py
@@ -141,6 +141,7 @@ class ApartmentReservationSerializerBase(serializers.ModelSerializer):
     class Meta:
         model = ApartmentReservation
         fields = (
+            "id",
             "apartment_uuid",
             "lottery_position",
             "queue_position",

--- a/application_form/api/views.py
+++ b/application_form/api/views.py
@@ -1,8 +1,9 @@
-from rest_framework import permissions
+from rest_framework import mixins, permissions, viewsets
 from rest_framework.generics import GenericAPIView
 from rest_framework.response import Response
 
 from apartment.elastic.queries import get_apartment_uuids
+from application_form.api.sales.serializers import RootApartmentReservationSerializer
 from application_form.api.serializers import (
     ApartmentReservationSerializer,
     ApplicationSerializer,
@@ -37,3 +38,9 @@ class ListProjectReservations(GenericAPIView):
         )
         serializer = self.get_serializer(reservations, many=True)
         return Response(serializer.data)
+
+
+class ApartmentReservationViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
+    queryset = ApartmentReservation.objects.all()
+    serializer_class = RootApartmentReservationSerializer
+    permission_classes = [permissions.AllowAny]

--- a/application_form/tests/api/test_apartment_reservation_api.py
+++ b/application_form/tests/api/test_apartment_reservation_api.py
@@ -1,8 +1,20 @@
 import pytest
+import uuid
+from datetime import date
+from decimal import Decimal
 from django.urls import reverse
 
+from apartment.tests.factories import ApartmentDocumentFactory
 from application_form.tests.factories import ApartmentReservationFactory
-from invoicing.tests.factories import ApartmentInstallmentFactory
+from invoicing.enums import (
+    InstallmentPercentageSpecifier,
+    InstallmentType,
+    InstallmentUnit,
+)
+from invoicing.tests.factories import (
+    ApartmentInstallmentFactory,
+    ProjectInstallmentTemplateFactory,
+)
 
 
 @pytest.mark.django_db
@@ -33,8 +45,93 @@ def test_root_apartment_reservation_detail(
                 "due_date": None,
             }
         ],
+        "installment_candidates": [],
         "apartment_uuid": reservation.apartment_uuid,
         "queue_position": reservation.queue_position,
         "state": reservation.state.value,
         "lottery_position": None,
+    }
+
+
+@pytest.mark.django_db
+def test_root_apartment_reservation_detail_installment_candidates(api_client):
+    apartment = ApartmentDocumentFactory(
+        sales_price=12345678, debt_free_sales_price=9876543  # 123456,78e and 98765,43e
+    )
+    project_uuid = apartment.project_uuid
+    reservation = ApartmentReservationFactory(apartment_uuid=apartment.uuid)
+    installment_template_1 = ProjectInstallmentTemplateFactory(
+        project_uuid=project_uuid,
+        type=InstallmentType.REFUND,
+        value=Decimal("100.50"),
+        unit=InstallmentUnit.EURO,
+        due_date=date(2022, 1, 10),
+    )
+    installment_template_2 = ProjectInstallmentTemplateFactory(
+        project_uuid=project_uuid,
+        type=InstallmentType.PAYMENT_1,
+        value=Decimal("10"),
+        unit=InstallmentUnit.PERCENT,
+        percentage_specifier=InstallmentPercentageSpecifier.SALES_PRICE,
+    )
+    installment_template_3 = ProjectInstallmentTemplateFactory(
+        project_uuid=project_uuid,
+        type=InstallmentType.PAYMENT_2,
+        value=Decimal("0.7"),
+        unit=InstallmentUnit.PERCENT,
+        percentage_specifier=InstallmentPercentageSpecifier.DEBT_FREE_SALES_PRICE,
+    )
+    installment_template_4 = ProjectInstallmentTemplateFactory(
+        project_uuid=project_uuid,
+        type=InstallmentType.PAYMENT_3,
+        value=Decimal("17.25"),
+        unit=InstallmentUnit.PERCENT,
+        percentage_specifier=InstallmentPercentageSpecifier.DEBT_FREE_SALES_PRICE_FLEXIBLE,  # noqa: E501
+    )
+    # another project
+    ProjectInstallmentTemplateFactory(
+        project_uuid=uuid.UUID("19867533-2a60-4b3f-b166-f13af513d2d2"),
+        type=InstallmentType.PAYMENT_1,
+        value=Decimal("53"),
+        unit=InstallmentUnit.EURO,
+    )
+
+    response = api_client.get(
+        reverse(
+            "application_form:sales-apartment-reservation-detail",
+            kwargs={"pk": reservation.id},
+        ),
+        format="json",
+    )
+    assert response.status_code == 200
+
+    installment_candidates = response.data["installment_candidates"]
+    assert len(installment_candidates) == 4
+
+    assert installment_candidates[0] == {
+        "type": installment_template_1.type.value,
+        "amount": 10050,
+        "account_number": installment_template_1.account_number,
+        "due_date": "2022-01-10",
+    }
+
+    assert installment_candidates[1] == {
+        "type": installment_template_2.type.value,
+        "amount": 1234568,  # 10% of 123456,78e in cents
+        "account_number": installment_template_2.account_number,
+        "due_date": None,
+    }
+
+    assert installment_candidates[2] == {
+        "type": installment_template_3.type.value,
+        "amount": 69136,  # 0,7% of 987654,43e in cents
+        "account_number": installment_template_3.account_number,
+        "due_date": None,
+    }
+
+    assert installment_candidates[3] == {
+        "type": installment_template_4.type.value,
+        "amount": 1703704,  # 17,25% of 987654,43e in cents
+        "account_number": installment_template_4.account_number,
+        "due_date": None,
     }

--- a/application_form/tests/api/test_apartment_reservation_api.py
+++ b/application_form/tests/api/test_apartment_reservation_api.py
@@ -1,0 +1,40 @@
+import pytest
+from django.urls import reverse
+
+from application_form.tests.factories import ApartmentReservationFactory
+from invoicing.tests.factories import ApartmentInstallmentFactory
+
+
+@pytest.mark.django_db
+def test_root_apartment_reservation_detail(
+    api_client, elastic_project_with_5_apartments
+):
+    _, apartments = elastic_project_with_5_apartments
+    reservation = ApartmentReservationFactory(apartment_uuid=apartments[0].uuid)
+    installment = ApartmentInstallmentFactory(apartment_reservation=reservation)
+
+    response = api_client.get(
+        reverse(
+            "application_form:sales-apartment-reservation-detail",
+            kwargs={"pk": reservation.id},
+        ),
+        format="json",
+    )
+    assert response.status_code == 200
+
+    assert response.data == {
+        "id": reservation.id,
+        "installments": [
+            {
+                "type": installment.type.value,
+                "amount": int(installment.value * 100),
+                "account_number": installment.account_number,
+                "reference_number": installment.reference_number,
+                "due_date": None,
+            }
+        ],
+        "apartment_uuid": reservation.apartment_uuid,
+        "queue_position": reservation.queue_position,
+        "state": reservation.state.value,
+        "lottery_position": None,
+    }

--- a/application_form/urls.py
+++ b/application_form/urls.py
@@ -5,13 +5,22 @@ from application_form.api.sales.views import (
     execute_lottery_for_project,
     SalesApplicationViewSet,
 )
-from application_form.api.views import ApplicationViewSet, ListProjectReservations
+from application_form.api.views import (
+    ApartmentReservationViewSet,
+    ApplicationViewSet,
+    ListProjectReservations,
+)
 from invoicing.api.views import ApartmentInstallmentAPIView
 
 router = DefaultRouter()
 router.register(r"applications", ApplicationViewSet)
 router.register(
     r"sales/applications", SalesApplicationViewSet, basename="sales-application"
+)
+router.register(
+    r"sales/apartment_reservations",
+    ApartmentReservationViewSet,
+    basename="sales-apartment-reservation",
 )
 
 

--- a/invoicing/api/serializers.py
+++ b/invoicing/api/serializers.py
@@ -145,6 +145,21 @@ class ProjectInstallmentTemplateSerializer(InstallmentSerializerBase):
         return data
 
 
+class ApartmentInstallmentSerializerBase(InstallmentSerializerBase):
+    amount = IntegerCentsField(
+        source="value",
+        required=False,
+        help_text=_("Value in cents."),
+    )
+
+    class Meta(InstallmentSerializerBase.Meta):
+        model = ApartmentInstallment
+
+
+class ApartmentInstallmentCandidateSerializer(ApartmentInstallmentSerializerBase):
+    pass
+
+
 @extend_schema_serializer(
     examples=[
         OpenApiExample(
@@ -168,13 +183,6 @@ class ProjectInstallmentTemplateSerializer(InstallmentSerializerBase):
         ),
     ]
 )
-class ApartmentInstallmentSerializer(InstallmentSerializerBase):
-    amount = IntegerCentsField(
-        source="value",
-        required=False,
-        help_text=_("Value in cents."),
-    )
-
-    class Meta(InstallmentSerializerBase.Meta):
-        model = ApartmentInstallment
-        fields = InstallmentSerializerBase.Meta.fields + ("reference_number",)
+class ApartmentInstallmentSerializer(ApartmentInstallmentSerializerBase):
+    class Meta(ApartmentInstallmentSerializerBase.Meta):
+        fields = ApartmentInstallmentSerializerBase.Meta.fields + ("reference_number",)

--- a/invoicing/api/serializers.py
+++ b/invoicing/api/serializers.py
@@ -1,3 +1,4 @@
+import secrets
 from decimal import Decimal
 from django.utils.translation import gettext_lazy as _
 from drf_spectacular.utils import extend_schema_serializer, OpenApiExample
@@ -186,3 +187,9 @@ class ApartmentInstallmentCandidateSerializer(ApartmentInstallmentSerializerBase
 class ApartmentInstallmentSerializer(ApartmentInstallmentSerializerBase):
     class Meta(ApartmentInstallmentSerializerBase.Meta):
         fields = ApartmentInstallmentSerializerBase.Meta.fields + ("reference_number",)
+
+    def validate(self, data):
+        if "reference_number" not in data:
+            # TODO generate real reference number
+            data["reference_number"] = f"REFERENCE-{secrets.choice(range(100, 999))}"
+        return data

--- a/invoicing/models.py
+++ b/invoicing/models.py
@@ -74,12 +74,10 @@ class ProjectInstallmentTemplate(InstallmentBase):
     def get_corresponding_apartment_installment(self, apartment_data):
         apartment_installment = ApartmentInstallment()
 
-        excluded_fields = ("id", "created_at")
-        for field_name in [
-            f.name
-            for f in InstallmentBase._meta.get_fields()
-            if f not in excluded_fields
-        ]:
+        field_names = [
+            f.name for f in InstallmentBase._meta.get_fields() if f.name != "created_at"
+        ]
+        for field_name in field_names:
             setattr(apartment_installment, field_name, getattr(self, field_name))
 
         if self.unit == InstallmentUnit.PERCENT:
@@ -98,7 +96,6 @@ class ProjectInstallmentTemplate(InstallmentBase):
             apartment_installment.value = get_rounded_price(
                 price * percentage_multiplier
             )
-
         else:
             apartment_installment.value = self.value
 

--- a/invoicing/models.py
+++ b/invoicing/models.py
@@ -10,6 +10,7 @@ from invoicing.enums import (
     InstallmentType,
     InstallmentUnit,
 )
+from invoicing.utils import get_euros_from_cents, get_rounded_price
 
 
 class InstallmentBase(models.Model):
@@ -25,6 +26,25 @@ class InstallmentBase(models.Model):
 
     class Meta:
         abstract = True
+
+
+class ApartmentInstallment(InstallmentBase):
+    apartment_reservation = models.ForeignKey(
+        ApartmentReservation,
+        verbose_name=_("apartment reservation"),
+        related_name="apartment_installments",
+        on_delete=models.PROTECT,
+    )
+    reference_number = models.CharField(
+        max_length=64, verbose_name=_("reference number"), blank=True
+    )
+
+    class Meta:
+        constraints = [
+            UniqueConstraint(
+                fields=["apartment_reservation", "type"], name="unique_reservation_type"
+            )
+        ]
 
 
 class ProjectInstallmentTemplate(InstallmentBase):
@@ -51,21 +71,35 @@ class ProjectInstallmentTemplate(InstallmentBase):
     def get_percentage(self):
         return self.value if self.unit == InstallmentUnit.PERCENT else None
 
+    def get_corresponding_apartment_installment(self, apartment_data):
+        apartment_installment = ApartmentInstallment()
 
-class ApartmentInstallment(InstallmentBase):
-    apartment_reservation = models.ForeignKey(
-        ApartmentReservation,
-        verbose_name=_("apartment reservation"),
-        related_name="apartment_installments",
-        on_delete=models.PROTECT,
-    )
-    reference_number = models.CharField(
-        max_length=64, verbose_name=_("reference number"), blank=True
-    )
+        excluded_fields = ("id", "created_at")
+        for field_name in [
+            f.name
+            for f in InstallmentBase._meta.get_fields()
+            if f not in excluded_fields
+        ]:
+            setattr(apartment_installment, field_name, getattr(self, field_name))
 
-    class Meta:
-        constraints = [
-            UniqueConstraint(
-                fields=["apartment_reservation", "type"], name="unique_reservation_type"
+        if self.unit == InstallmentUnit.PERCENT:
+            if not self.percentage_specifier:
+                raise ValueError(
+                    f"Cannot calculate apartment installment value, {self} "
+                    f"has no percentage_specifier"
+                )
+            if self.percentage_specifier == InstallmentPercentageSpecifier.SALES_PRICE:
+                price_in_cents = apartment_data["sales_price"]
+            else:
+                price_in_cents = apartment_data["debt_free_sales_price"]
+
+            price = get_euros_from_cents(price_in_cents)
+            percentage_multiplier = self.value / 100
+            apartment_installment.value = get_rounded_price(
+                price * percentage_multiplier
             )
-        ]
+
+        else:
+            apartment_installment.value = self.value
+
+        return apartment_installment

--- a/invoicing/tests/test_api.py
+++ b/invoicing/tests/test_api.py
@@ -356,3 +356,32 @@ def test_set_apartment_installments(profile_api_client, has_old_installments):
     assert installment_2.account_number == "123123123-123"
     assert installment_2.due_date is None
     assert installment_2.reference_number == "REFERENCE-321"
+
+
+@pytest.mark.django_db
+def test_apartment_installment_reference_number_populating(profile_api_client):
+    reservation = ApartmentReservationFactory()
+
+    data = [
+        {
+            "type": "PAYMENT_1",
+            "amount": 100000,
+            "account_number": "123123123-123",
+            "due_date": "2022-02-19",
+        }
+    ]
+
+    response = profile_api_client.post(
+        reverse(
+            "application_form:apartment-installment-list",
+            kwargs={"apartment_reservation_id": reservation.id},
+        ),
+        data=data,
+        format="json",
+    )
+
+    assert response.data[0]["reference_number"].startswith("REFERENCE-")
+    assert (
+        ApartmentInstallment.objects.first().reference_number
+        == response.data[0]["reference_number"]
+    )

--- a/invoicing/utils.py
+++ b/invoicing/utils.py
@@ -1,0 +1,9 @@
+from decimal import Decimal, ROUND_UP
+
+
+def get_rounded_price(price: Decimal) -> Decimal:
+    return price.quantize(Decimal(".01"), rounding=ROUND_UP)
+
+
+def get_euros_from_cents(in_cents: int) -> Decimal:
+    return Decimal(in_cents) / 100


### PR DESCRIPTION
Implemented API which makes it possible to create apartment installments from project installment templates. This needs a reservation detail endpoint, so that is first created to URL `/v1/sales/apartment_reservations/<reservation id>/`.

When creating apartment installments, one needs to first get installment candidates for the reservation from the reservation detail endpoint, and then use those with or without changes to actually create the apartment installments (via `/v1/sales/apartment_reservations/<reservation id>/installments/`).

Added also initial dummy implementation for generating installment reference numbers.