### PR TITLE
Fix project detail API endpoint apartment list

### DIFF
--- a/apartment/api/serializers.py
+++ b/apartment/api/serializers.py
@@ -149,5 +149,5 @@ class ProjectDocumentDetailSerializer(ProjectDocumentSerializerBase):
         ).data
 
     def get_apartments(self, obj):
-        apartments = get_apartments(obj.uuid)
+        apartments = get_apartments(obj.project_uuid)
         return ApartmentSerializer(apartments, many=True).data


### PR DESCRIPTION
Before this fix the apartment list in the project detail API endpoint included all the apartments there are in the db, now it correctly includes only the apartments of the project.