### PR TITLE
Embetter Customer Profile validation

### DIFF
--- a/customer/models.py
+++ b/customer/models.py
@@ -74,12 +74,18 @@ class Customer(TimestampedModel):
         )
 
     def clean(self):
-        if (
-            not self.secondary_profile
-            and self.__class__.objects.exclude(id=self.id)
-            .filter(primary_profile=self.primary_profile)
-            .exists()
+        if self.__class__.objects.exclude(id=self.id).filter(
+            primary_profile=self.primary_profile,
+            secondary_profile=self.secondary_profile,
         ):
             raise ValidationError(
-                _("There already exists a Customer for the primary profile.")
+                _(
+                    "There already exists a Customer which has the same primary and "
+                    "secondary profile."
+                )
             )
+        return
+
+    def save(self, *args, **kwargs):
+        self.clean()
+        super().save(*args, **kwargs)

--- a/customer/tests/test_customer_models.py
+++ b/customer/tests/test_customer_models.py
@@ -3,7 +3,6 @@ Test cases for customer models.
 """
 import pytest
 from django.core.exceptions import ValidationError
-from django.db import IntegrityError, transaction
 
 from customer.models import Customer
 from customer.tests.factories import CustomerFactory
@@ -38,27 +37,20 @@ def test_customer_validation():
         primary_profile=two_profile_customer.primary_profile,
         secondary_profile=ProfileFactory(),
     )
+    CustomerFactory(
+        primary_profile=two_profile_customer.primary_profile,
+        secondary_profile=None,
+    )
 
     with pytest.raises(ValidationError):
         # customers with the same primary and no secondary profile are not allowed
-        customer = CustomerFactory.build(
+        CustomerFactory(
             primary_profile=one_profile_customer.primary_profile, secondary_profile=None
         )
-        customer.clean()
 
-    with transaction.atomic():
-        with pytest.raises(IntegrityError):
-            # customers with the same primary and no secondary profile are not allowed.
-            # make sure it is checked on db level as well.
-            CustomerFactory(
-                primary_profile=one_profile_customer.primary_profile,
-                secondary_profile=None,
-            )
-
-    with transaction.atomic():
-        with pytest.raises(IntegrityError):
-            # customers with the same primary and secondary profiles are not allowed
-            CustomerFactory(
-                primary_profile=two_profile_customer.primary_profile,
-                secondary_profile=two_profile_customer.secondary_profile,
-            )
+    with pytest.raises(ValidationError):
+        # customers with the same primary and secondary profiles are not allowed
+        CustomerFactory(
+            primary_profile=two_profile_customer.primary_profile,
+            secondary_profile=two_profile_customer.secondary_profile,
+        )


### PR DESCRIPTION
Simplified Customer profiles' validation a bit and changed clean() to be called on save() for consistency reasons. At the same time, a bug in the validation that prevented single profile Customers to be created on some occasions got fixed.