### PR TITLE
ASU-1378 | Hide queue position when lottery hasn't been executed yet

### DIFF
--- a/apartment/api/sales/serializers.py
+++ b/apartment/api/sales/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from application_form.api.sales.serializers import ApartmentReservationSerializer
+from application_form.api.sales.serializers import SalesApartmentReservationSerializer
 from application_form.models import ApartmentReservation
 
 
@@ -19,4 +19,4 @@ class ApartmentSerializer(serializers.Serializer):
             "list_position",
             "queue_position",
         )
-        return ApartmentReservationSerializer(reservations, many=True).data
+        return SalesApartmentReservationSerializer(reservations, many=True).data

--- a/application_form/api/sales/serializers.py
+++ b/application_form/api/sales/serializers.py
@@ -44,7 +44,7 @@ class ApplicantCompactSerializer(serializers.ModelSerializer):
         fields = ["first_name", "last_name", "is_primary_applicant", "email"]
 
 
-class ApartmentReservationSerializer(ApartmentReservationSerializerBase):
+class SalesApartmentReservationSerializer(ApartmentReservationSerializerBase):
     applicants = ApplicantCompactSerializer(
         source="application_apartment.application.applicants", many=True
     )

--- a/application_form/api/serializers.py
+++ b/application_form/api/serializers.py
@@ -143,6 +143,7 @@ class ApplicationSerializer(ApplicationSerializerBase):
 
 class ApartmentReservationSerializerBase(serializers.ModelSerializer):
     state = EnumField(ApartmentReservationState)
+    queue_position = serializers.SerializerMethodField()
 
     class Meta:
         model = ApartmentReservation
@@ -153,6 +154,15 @@ class ApartmentReservationSerializerBase(serializers.ModelSerializer):
             "queue_position",
             "state",
         )
+
+    def get_queue_position(self, obj):
+        try:
+            lottery_result = obj.application_apartment.lotteryeventresult
+            if lottery_result:
+                return obj.queue_position
+        except AttributeError:
+            pass
+        return None
 
 
 class ApartmentReservationSerializer(ApartmentReservationSerializerBase):

--- a/customer/tests/api/sales/test_customer_api.py
+++ b/customer/tests/api/sales/test_customer_api.py
@@ -82,7 +82,7 @@ def test_get_customer_api_detail(api_client):
                 }
             ],
             "list_position": reservation.list_position,
-            "queue_position": reservation.queue_position,
+            "queue_position": None,
             "state": reservation.state.value,
         }
     ]


### PR DESCRIPTION
- Hide queue position if lottery hasn't been executed yet
- Rename ApartmentReservationSerializer to SaleApartmentSerializer ( there were two ApartmentReservationSerializer classes)
