### PR TITLE
ASU-1346 | Add apartment state

### DIFF
--- a/apartment/api/sales/serializers.py
+++ b/apartment/api/sales/serializers.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 
+from apartment.enums import ApartmentState
 from application_form.api.sales.serializers import SalesApartmentReservationSerializer
 from application_form.models import ApartmentReservation
 
@@ -11,6 +12,7 @@ class ApartmentSerializer(serializers.Serializer):
     living_area = serializers.FloatField()
     reservations = serializers.SerializerMethodField()
     url = serializers.CharField()
+    state = serializers.SerializerMethodField()
 
     def get_reservations(self, obj):
         reservations = ApartmentReservation.objects.filter(
@@ -19,8 +21,23 @@ class ApartmentSerializer(serializers.Serializer):
             "list_position",
             "queue_position",
         )
+
         return SalesApartmentReservationSerializer(
             reservations,
             many=True,
             context={"project_uuid": self.context["project_uuid"]},
         ).data
+
+    def get_state(self, obj):
+        try:
+            reserved_reservation = ApartmentReservation.objects.reserved().get(
+                apartment_uuid=obj.uuid
+            )
+        except ApartmentReservation.DoesNotExist:
+            return ApartmentState.FREE.value
+        except ApartmentReservation.MultipleObjectsReturned:
+            return ApartmentState.REVIEW.value
+
+        return ApartmentState.get_from_reserved_reservation_state(
+            reserved_reservation.state
+        ).value

--- a/apartment/enums.py
+++ b/apartment/enums.py
@@ -1,5 +1,7 @@
 from enum import Enum
 
+from application_form.enums import ApartmentReservationState
+
 
 class IdentifierSchemaType(Enum):
     ATT_PROJECT_ES = "att_pro_es"
@@ -9,3 +11,33 @@ class OwnershipType(Enum):
     HASO = "haso"
     HITAS = "hitas"
     PUOLIHITAS = "puolihitas"
+
+
+class ApartmentState(Enum):
+    FREE = "free"
+    RESERVED = "reserved"
+    RESERVATION_AGREEMENT = "reservation_agreement"
+    OFFERED = "offered"
+    OFFER_ACCEPTED = "offer_accepted"
+    OFFER_EXPIRED = "offer_expired"
+    ACCEPTED_BY_MUNICIPALITY = "accepted_by_municipality"
+    SOLD = "sold"
+    REVIEW = "review"
+
+    @classmethod
+    def get_from_reserved_reservation_state(
+        cls, reservation_state: ApartmentReservationState
+    ):
+        try:
+            return {
+                ApartmentReservationState.RESERVED: cls.RESERVED,
+                ApartmentReservationState.RESERVATION_AGREEMENT: cls.RESERVATION_AGREEMENT,  # noqa: E501
+                ApartmentReservationState.OFFERED: cls.OFFERED,
+                ApartmentReservationState.OFFER_ACCEPTED: cls.OFFER_ACCEPTED,
+                ApartmentReservationState.OFFER_EXPIRED: cls.OFFER_EXPIRED,
+                ApartmentReservationState.ACCEPTED_BY_MUNICIPALITY: cls.ACCEPTED_BY_MUNICIPALITY,  # noqa: E501
+                ApartmentReservationState.SOLD: cls.SOLD,
+                ApartmentReservationState.REVIEW: cls.REVIEW,
+            }[reservation_state]
+        except KeyError:
+            raise ValueError(f"Invalid reserved reservation state {reservation_state}")

--- a/apartment/tests/conftest.py
+++ b/apartment/tests/conftest.py
@@ -6,6 +6,8 @@ from pytest import fixture
 from rest_framework.test import APIClient
 
 from apartment.tests.factories import ApartmentDocumentFactory
+from users.tests.factories import ProfileFactory
+from users.tests.utils import _create_token
 
 faker.config.DEFAULT_LOCALE = "fi_FI"
 
@@ -13,6 +15,14 @@ faker.config.DEFAULT_LOCALE = "fi_FI"
 @fixture
 def api_client():
     api_client = APIClient()
+    return api_client
+
+
+@fixture
+def profile_api_client():
+    api_client = APIClient()
+    profile = ProfileFactory()
+    api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {_create_token(profile)}")
     return api_client
 
 


### PR DESCRIPTION
Added `state` field to the apartment data in the sales API project detail endpoint. The value will be determined from the current winning reservation of the apartment. Before the apartment's lottery, the value will be always `free`.