### PR TITLE
ASU-1332 | Add ApartmentReservation create API

### DIFF
--- a/apartment/elastic/queries.py
+++ b/apartment/elastic/queries.py
@@ -13,7 +13,10 @@ def get_apartment(apartment_uuid, include_project_fields=False):
         search = search.source(excludes=["project_*"])
 
     # Get item
-    apartment = search.execute()[0]
+    try:
+        apartment = search.execute()[0]
+    except IndexError:
+        raise ObjectDoesNotExist("Apartment does not exist in ElasticSearch.")
 
     return apartment
 

--- a/application_form/api/sales/views.py
+++ b/application_form/api/sales/views.py
@@ -75,7 +75,9 @@ class SalesApplicationViewSet(ApplicationViewSet):
     permission_classes = [permissions.IsAuthenticated, IsSalesperson]
 
 
-class ApartmentReservationViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
+class ApartmentReservationViewSet(
+    mixins.RetrieveModelMixin, mixins.CreateModelMixin, viewsets.GenericViewSet
+):
     queryset = ApartmentReservation.objects.all()
     serializer_class = RootApartmentReservationSerializer
     permission_classes = [permissions.AllowAny]

--- a/application_form/utils.py
+++ b/application_form/utils.py
@@ -1,0 +1,15 @@
+from contextlib import contextmanager
+from django.db import transaction
+from django.db.transaction import get_connection
+
+
+# from https://stackoverflow.com/a/54403001
+@contextmanager
+def lock_table(model):
+    with transaction.atomic():
+        cursor = get_connection().cursor()
+        cursor.execute(f"LOCK TABLE {model._meta.db_table}")
+        try:
+            yield
+        finally:
+            cursor.close()


### PR DESCRIPTION
Implemented ApartmentReservation creation functionality to ApartmentReservationViewSet. It is used by issuing a POST request to URL /v1/sales/apartment_reservations/.

Reservations can be added at the end of the apartment's reservation queue. If there are no existing reservations in the queue, the newly created reservation will get state RESERVED, otherwise it will get state SUBMITTED.

### Example request:
**HTTP POST /v1/sales/aparment_reservations/**
```json
{
	"apartment_uuid": "1623bb70-74c0-44a5-b96b-a3ccf96a05f6",
	"customer_id": 3
}
```

### Example response:
**HTTP 201**
```json
{
	"installments": [],
	"installment_candidates": [],
	"customer_id": 3,
	"id": 28,
	"apartment_uuid": "1623bb70-74c0-44a5-b96b-a3ccf96a05f6",
	"list_position": 11,
	"queue_position": 11,
	"priority_number": null,
	"state": "submitted"
}
```