### PR TITLE
ASU-1439 | Change customer ID to customer object in project detail API

### DIFF
--- a/apartment/tests/api/test_views.py
+++ b/apartment/tests/api/test_views.py
@@ -14,7 +14,7 @@ from application_form.tests.factories import (
 )
 from customer.tests.factories import CustomerFactory
 from users.tests.factories import ProfileFactory
-from users.tests.utils import _create_token
+from users.tests.utils import _create_token, assert_customer_match_data
 
 
 @pytest.mark.django_db
@@ -175,6 +175,12 @@ def test_project_detail_apartment_reservations(
         )
 
         _assert_apartment_reservations_data(apartment_data["reservations"])
+        for reservation_data in apartment_data["reservations"]:
+            assert_customer_match_data(
+                ApartmentReservation.objects.get(id=reservation_data["id"]).customer,
+                reservation_data["customer"],
+                compact=True,
+            )
 
 
 @pytest.mark.django_db
@@ -242,7 +248,7 @@ def test_project_detail_apartment_reservations_multiple_winning(
     for apartment_data in apartments_data:
         for reservation in apartment_data["reservations"]:
             assert reservation["has_multiple_winning_apartments"] == (
-                reservation["customer"] == customer.id
+                reservation["customer"]["id"] == customer.id
             )
 
 

--- a/application_form/api/sales/serializers.py
+++ b/application_form/api/sales/serializers.py
@@ -48,13 +48,32 @@ class ApplicantCompactSerializer(serializers.ModelSerializer):
         fields = ["first_name", "last_name", "is_primary_applicant", "email"]
 
 
+class ProfileCompactSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Profile
+        fields = (
+            "first_name",
+            "last_name",
+            "email",
+        )
+
+
+class CustomerCompactSerializer(serializers.ModelSerializer):
+    primary_profile = ProfileCompactSerializer()
+    secondary_profile = ProfileCompactSerializer()
+
+    class Meta:
+        model = Customer
+        fields = ("id", "primary_profile", "secondary_profile")
+
+
 class SalesApartmentReservationSerializer(ApartmentReservationSerializerBase):
     applicants = ApplicantCompactSerializer(
         source="application_apartment.application.applicants",
         many=True,
         allow_null=True,
     )
-    customer = serializers.PrimaryKeyRelatedField(read_only=True)
+    customer = CustomerCompactSerializer()
 
     # HITAS fields
     has_children = serializers.SerializerMethodField()


### PR DESCRIPTION
The sales UI requires this change to display customer information in reservation lists. Currently it uses "applicants" data, but that doesn't work for reservations without an application.