### PR TITLE
ASU-1455 | Remove applicants field from project detail API

### DIFF
--- a/application_form/api/sales/serializers.py
+++ b/application_form/api/sales/serializers.py
@@ -69,11 +69,6 @@ class CustomerCompactSerializer(serializers.ModelSerializer):
 
 
 class SalesApartmentReservationSerializer(ApartmentReservationSerializerBase):
-    applicants = ApplicantCompactSerializer(
-        source="application_apartment.application.applicants",
-        many=True,
-        allow_null=True,
-    )
     customer = CustomerCompactSerializer()
 
     # HITAS fields
@@ -91,7 +86,6 @@ class SalesApartmentReservationSerializer(ApartmentReservationSerializerBase):
 
     class Meta(ApartmentReservationSerializerBase.Meta):
         fields = ApartmentReservationSerializerBase.Meta.fields + (
-            "applicants",
             "customer",
             "has_children",
             "right_of_residence",


### PR DESCRIPTION
Applicant data is not needed anymore in project detail API because the Sales UI uses customer data now instead.