### PR TITLE
Fix apartment installment SAP fields handling on API edit

### DIFF
--- a/invoicing/api/serializers.py
+++ b/invoicing/api/serializers.py
@@ -190,5 +190,9 @@ class ApartmentInstallmentSerializer(ApartmentInstallmentSerializerBase):
     def create(self, validated_data):
         if old_instance := self.context["old_instances"].get(validated_data["type"]):
             validated_data["reference_number"] = old_instance.reference_number
+            validated_data[
+                "added_to_be_sent_to_sap_at"
+            ] = old_instance.added_to_be_sent_to_sap_at
+            validated_data["sent_to_sap_at"] = old_instance.sent_to_sap_at
 
         return super().create(validated_data)


### PR DESCRIPTION
Before this fix, ApartmentInstallment fields added_to_be_sent_to_sap_at and sent_to_sap_at were nullified when the apartment's installments where edited.

We need to prevent editing of certain installment rows in the future, which will probably require some refactoring to the whole installment edit API, so this fix is likely to be just a temporary one.
