### PR TITLE
Fix date checks to use local time

### DIFF
--- a/apartment/tests/factories.py
+++ b/apartment/tests/factories.py
@@ -177,12 +177,12 @@ class ApartmentDocumentFactory(ElasticFactory):
     right_of_occupancy_payment = fuzzy.FuzzyInteger(0, 999)
     right_of_occupancy_fee = fuzzy.FuzzyInteger(0, 999)
     project_contract_apartment_completion_selection_2_start = fuzzy.FuzzyDate(
-        start_date=timezone.now().date() - timedelta(days=7),
-        end_date=timezone.now().date() - timedelta(days=1),
+        start_date=timezone.localdate() - timedelta(days=7),
+        end_date=timezone.localdate() - timedelta(days=1),
     )
     project_contract_apartment_completion_selection_2_end = fuzzy.FuzzyDate(
-        start_date=timezone.now().date() + timedelta(days=1),
-        end_date=timezone.now().date() + timedelta(days=7),
+        start_date=timezone.localdate() + timedelta(days=1),
+        end_date=timezone.localdate() + timedelta(days=7),
     )
     project_contract_other_terms = fuzzy.FuzzyText()
     project_contract_usage_fees = fuzzy.FuzzyText()

--- a/application_form/models/offer.py
+++ b/application_form/models/offer.py
@@ -13,7 +13,7 @@ class OfferQuerySet(models.QuerySet):
     def active(self):
         return self.filter(
             Q(state=OfferState.ACCEPTED)
-            | Q(Q(state=OfferState.PENDING) & Q(valid_until__gte=timezone.now().date()))
+            | Q(Q(state=OfferState.PENDING) & Q(valid_until__gte=timezone.localdate()))
         )
 
 

--- a/application_form/services/offer.py
+++ b/application_form/services/offer.py
@@ -66,7 +66,7 @@ def update_reservation_state_based_on_offer_expiration(
 def update_reservations_based_on_offer_expiration(
     reservation_qs=None, user: User = None
 ) -> (int, int):
-    today = timezone.now().date()
+    today = timezone.localdate()
 
     if not reservation_qs:
         reservation_qs = ApartmentReservation.objects.all()

--- a/application_form/tests/api/test_offer_api.py
+++ b/application_form/tests/api/test_offer_api.py
@@ -12,7 +12,7 @@ from application_form.tests.factories import ApartmentReservationFactory, OfferF
 def test_create_offer(user_api_client):
     apartment = ApartmentDocumentFactory()
     reservation = ApartmentReservationFactory(apartment_uuid=apartment.uuid)
-    week_in_future = timezone.now().date() + timedelta(days=7)
+    week_in_future = timezone.localdate() + timedelta(days=7)
 
     data = {
         "apartment_reservation_id": reservation.id,
@@ -52,7 +52,7 @@ def test_create_offer(user_api_client):
 def test_create_offer_already_exists(user_api_client):
     apartment = ApartmentDocumentFactory()
     reservation = ApartmentReservationFactory(apartment_uuid=apartment.uuid)
-    week_in_future = timezone.now().date() + timedelta(days=7)
+    week_in_future = timezone.localdate() + timedelta(days=7)
 
     data = {
         "apartment_reservation_id": reservation.id,
@@ -80,7 +80,7 @@ def test_create_offer_already_exists(user_api_client):
 
 @pytest.mark.django_db
 def test_update_offer(user_api_client):
-    today = timezone.now().date()
+    today = timezone.localdate()
     apartment = ApartmentDocumentFactory()
     reservation = ApartmentReservationFactory(apartment_uuid=apartment.uuid)
     offer = OfferFactory(
@@ -130,7 +130,7 @@ def test_update_offer_change_state(user_api_client, new_state):
     )
     offer = OfferFactory(
         apartment_reservation=reservation,
-        valid_until=timezone.now().date() + timedelta(days=1),
+        valid_until=timezone.localdate() + timedelta(days=1),
     )
 
     data = {"state": new_state}
@@ -166,7 +166,7 @@ def test_cannot_update_concluded_offer_valid_until_or_state(user_api_client, sta
     reservation = ApartmentReservationFactory(apartment_uuid=apartment.uuid)
     offer = OfferFactory(
         apartment_reservation=reservation,
-        valid_until=timezone.now().date() + timedelta(days=1),
+        valid_until=timezone.localdate() + timedelta(days=1),
         state=state,
     )
 
@@ -197,7 +197,7 @@ def test_update_concluded_offer_comment(user_api_client, state):
     reservation = ApartmentReservationFactory(apartment_uuid=apartment.uuid)
     offer = OfferFactory(
         apartment_reservation=reservation,
-        valid_until=timezone.now().date() + timedelta(days=1),
+        valid_until=timezone.localdate() + timedelta(days=1),
         state=state,
         comment="old comment",
     )
@@ -221,7 +221,7 @@ def test_update_concluded_offer_comment(user_api_client, state):
 
 @pytest.mark.django_db
 def test_update_offer_change_to_expired(user_api_client):
-    today = timezone.now().date()
+    today = timezone.localdate()
     apartment = ApartmentDocumentFactory()
     reservation = ApartmentReservationFactory(
         apartment_uuid=apartment.uuid, state=ApartmentReservationState.OFFERED

--- a/application_form/tests/factories.py
+++ b/application_form/tests/factories.py
@@ -139,6 +139,6 @@ class OfferFactory(factory.django.DjangoModelFactory):
     apartment_reservation = factory.SubFactory(ApartmentReservationFactory)
     comment = fuzzy.FuzzyText()
     valid_until = fuzzy.FuzzyDate(
-        start_date=timezone.now().date() + timedelta(days=7),
-        end_date=timezone.now().date() + timedelta(days=14),
+        start_date=timezone.localdate() + timedelta(days=7),
+        end_date=timezone.localdate() + timedelta(days=14),
     )

--- a/application_form/tests/test_commands.py
+++ b/application_form/tests/test_commands.py
@@ -9,7 +9,7 @@ from application_form.tests.factories import OfferFactory
 
 @pytest.mark.django_db
 def test_update_reservations_based_on_offer_expiration():
-    today = timezone.now().date()
+    today = timezone.localdate()
     yesterday = today - timedelta(days=1)
 
     offers = (

--- a/invoicing/models.py
+++ b/invoicing/models.py
@@ -42,7 +42,7 @@ class InstallmentBase(models.Model):
 
 class ApartmentInstallmentQuerySet(models.QuerySet):
     def sending_to_sap_needed(self):
-        max_due_date = timezone.now().date() + timedelta(
+        max_due_date = timezone.localdate() + timedelta(
             days=settings.SAP_DAYS_UNTIL_INSTALLMENT_DUE_DATE
         )
         return self.filter(

--- a/invoicing/tests/test_commands.py
+++ b/invoicing/tests/test_commands.py
@@ -26,7 +26,7 @@ def test_pending_installments_to_sap(send_xml_to_sap):
         apartment_reservation__list_position=2,
         added_to_be_sent_to_sap_at=timezone.now(),
         sent_to_sap_at=None,
-        due_date=timezone.now().date()
+        due_date=timezone.localdate()
         + timedelta(days=settings.SAP_DAYS_UNTIL_INSTALLMENT_DUE_DATE + 1),
     )
     should_get_sent = ApartmentInstallmentFactory(


### PR DESCRIPTION
There were many occasions, where date based checks used `timezone.now().date()` to get the current date. That will return the date in UTC timezone, so it will not change correctly at midnight in Finnish time. Changed all those occurrences to use `timezone.localdate()` instead.