### PR TITLE
Fix drf-oidc-auth rejecting API tokens older than 10min

### DIFF
--- a/apartment_application_service/settings.py
+++ b/apartment_application_service/settings.py
@@ -274,6 +274,10 @@ OIDC_API_TOKEN_AUTH = {
     "ISSUER": env("OIDC_ISSUER"),
 }
 
+# drf-oidc-auth rejects tokens older this so we don't want to use the default value 600s
+# see https://github.com/ByteInternet/drf-oidc-auth/issues/28
+OIDC_AUTH = {"OIDC_LEEWAY": 61 * 60}
+
 SOCIAL_AUTH_TUNNISTAMO_KEY = env("SOCIAL_AUTH_TUNNISTAMO_KEY")
 SOCIAL_AUTH_TUNNISTAMO_SECRET = env("SOCIAL_AUTH_TUNNISTAMO_SECRET")
 SOCIAL_AUTH_TUNNISTAMO_OIDC_ENDPOINT = env("SOCIAL_AUTH_TUNNISTAMO_OIDC_ENDPOINT")


### PR DESCRIPTION
Added setting `OIDC_LEEWAY` with a value of 61 mins for `drf-oidc-auth`, because otherwise it will reject API tokens when they are older than the default value of 10 mins.