### PR TITLE
ASU-1519 | Add valid_until to offer messages

### DIFF
--- a/application_form/api/sales/serializers.py
+++ b/application_form/api/sales/serializers.py
@@ -246,7 +246,9 @@ class OfferMessageSerializer(serializers.Serializer):
         fields = ("subject", "body", "recipients")
 
     def to_representation(self, instance: ApartmentReservation):
-        subject, body = get_offer_message_subject_and_body(instance)
+        subject, body = get_offer_message_subject_and_body(
+            instance, valid_until=self.context.get("valid_until")
+        )
         recipients = RecipientSerializer(
             [
                 p

--- a/application_form/api/serializers.py
+++ b/application_form/api/serializers.py
@@ -289,3 +289,7 @@ class ApartmentReservationCancelEventSerializer(
             ret.pop("new_customer_id", None)
             ret.pop("new_reservation_id", None)
         return ret
+
+
+class OfferMessageQueryParamsSerializer(serializers.Serializer):
+    valid_until = serializers.DateField(required=False)

--- a/application_form/tests/api/test_apartment_reservation_api.py
+++ b/application_form/tests/api/test_apartment_reservation_api.py
@@ -792,12 +792,11 @@ def test_get_offer_message(salesperson_api_client, ownership_type):
         customer__primary_profile__email="ulla@example.com",
     )
 
-    response = salesperson_api_client.get(
-        reverse(
-            "application_form:sales-apartment-reservation-offer-message",
-            kwargs={"pk": reservation.id},
-        ),
-    )
+    url = reverse(
+        "application_form:sales-apartment-reservation-offer-message",
+        kwargs={"pk": reservation.id},
+    ) + ("?valid_until=2022-03-04" if ownership_type == "haso" else "")
+    response = salesperson_api_client.get(url)
     assert response.status_code == 200
 
     expected_subject = "Tarjous As Oy Pojanlohi A1"
@@ -818,6 +817,8 @@ Asumisoikeusnumero: 777
 Yli 55v: Kyllä
 Asumisoikeusasunnon vaihtaja: Ei
 
+Tarjouksen viimeinen voimassaolopäivä: 4.3.2022
+
 this
 is
 content
@@ -837,6 +838,8 @@ Velaton hinta: 5 000,00 €
 Alustava vastike: 100,00 €
 
 Lapsiperhe: Ei tiedossa
+
+Tarjouksen viimeinen voimassaolopäivä: Ei tiedossa
 
 this
 is
@@ -865,12 +868,7 @@ content
     )
     reservation.customer.save()
 
-    response = salesperson_api_client.get(
-        reverse(
-            "application_form:sales-apartment-reservation-offer-message",
-            kwargs={"pk": reservation.id},
-        ),
-    )
+    response = salesperson_api_client.get(url)
     assert response.status_code == 200
 
     expected_data["recipients"].append(


### PR DESCRIPTION
Added valid_until date to the offer messages that can be generated for reservations. The value can be given in the offer message API request with query parameter valid_until=<YYYY-MM-DD>. If the parameter is not used, the value of the reservation's offer instance will be used if one exists.

This functionality is needed because the Sales UI needs to fetch offer messages with valid until dates also for reservations that do not have an existing offer yet.