### PR TITLE
ASU-1469 & ASU-1473 | Additions to customer detail endpoint reservation history

### DIFF
--- a/application_form/api/serializers.py
+++ b/application_form/api/serializers.py
@@ -222,7 +222,7 @@ class ApartmentReservationStateChangeEventSerializer(
 ):
     class Meta:
         model = ApartmentReservationStateChangeEvent
-        fields = ("timestamp", "state", "comment")
+        fields = ("timestamp", "state", "comment", "cancellation_reason")
         read_only_fields = ("timestamp",)
 
     def __init__(self, *args, **kwargs):

--- a/application_form/api/serializers.py
+++ b/application_form/api/serializers.py
@@ -1,4 +1,5 @@
 import logging
+from django.contrib.auth import get_user_model
 from enumfields.drf import EnumField, EnumSupportSerializerMixin
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
@@ -23,6 +24,9 @@ from application_form.validators import ProjectApplicantValidator, SSNSuffixVali
 from customer.models import Customer
 
 _logger = logging.getLogger(__name__)
+
+
+User = get_user_model()
 
 
 class ApplicantSerializerBase(serializers.ModelSerializer):
@@ -217,13 +221,26 @@ class ApartmentReservationSerializer(ApartmentReservationSerializerBase):
     pass
 
 
+class ApartmentReservationStateChangeEventUserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ("id", "first_name", "last_name", "email")
+
+
 class ApartmentReservationStateChangeEventSerializer(
     EnumSupportSerializerMixin, serializers.ModelSerializer
 ):
+    changed_by = ApartmentReservationStateChangeEventUserSerializer(
+        source="user", read_only=True
+    )
+
     class Meta:
         model = ApartmentReservationStateChangeEvent
-        fields = ("timestamp", "state", "comment", "cancellation_reason")
-        read_only_fields = ("timestamp",)
+        fields = ("timestamp", "state", "comment", "cancellation_reason", "changed_by")
+        read_only_fields = (
+            "timestamp",
+            "changed_by",
+        )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/application_form/models/reservation.py
+++ b/application_form/models/reservation.py
@@ -126,9 +126,6 @@ class ApartmentReservation(models.Model):
         cancellation_reason: ApartmentReservationCancellationReason = None,
         replaced_by: "ApartmentReservation" = None,
     ) -> "ApartmentReservationStateChangeEvent":
-        if user and user.is_anonymous:
-            # TODO this should be removed after proper authentication has been added
-            user = None
         if cancellation_reason and state != ApartmentReservationState.CANCELED:
             raise ValidationError(
                 "cancellation_reason cannot be set when state is not canceled."

--- a/application_form/tests/api/test_apartment_reservation_api.py
+++ b/application_form/tests/api/test_apartment_reservation_api.py
@@ -277,11 +277,19 @@ def test_apartment_reservation_set_state(salesperson_api_client, comment):
     )
     assert response.status_code == 200
 
-    assert len(response.data.keys()) == 3
     assert response.data.pop("timestamp")
+
+    user = salesperson_api_client.user
     assert response.data == {
         "state": "reserved",
         "comment": comment,
+        "cancellation_reason": None,
+        "changed_by": {
+            "id": user.id,
+            "first_name": user.first_name,
+            "last_name": user.last_name,
+            "email": user.email,
+        },
     }
 
     assert reservation.state_change_events.count() == 2

--- a/customer/tests/api/sales/test_customer_api.py
+++ b/customer/tests/api/sales/test_customer_api.py
@@ -18,11 +18,7 @@ from customer.tests.utils import assert_customer_list_match_data
 from invoicing.tests.factories import ApartmentInstallmentFactory
 from users.models import Profile
 from users.tests.factories import ProfileFactory
-from users.tests.utils import (
-    _create_token,
-    assert_customer_match_data,
-    assert_profile_match_data,
-)
+from users.tests.utils import assert_customer_match_data, assert_profile_match_data
 
 
 @pytest.mark.django_db
@@ -57,10 +53,6 @@ def test_get_customer_api_detail(salesperson_api_client):
         apartment_reservation=reservation, value=100
     )
 
-    profile = ProfileFactory()
-    salesperson_api_client.credentials(
-        HTTP_AUTHORIZATION=f"Bearer {_create_token(profile)}"
-    )
     response = salesperson_api_client.get(
         reverse("customer:sales-customer-detail", args=(customer.pk,)),
         format="json",


### PR DESCRIPTION
Added `cancellation_reason` and `changed_by` to reservation state change history (`state_changes`) in customer detail endpoint.

GET `/v1/sales/customers/<id>/`
```json
{
  ...
  "apartment_reservations": [
    {
      ...
      "state_change_events": [
        {
          "timestamp": "2022-06-13T11:56:36.222628+03:00",
          "state": "reserved",
          "comment": "",
          "cancellation_reason": null,
          "changed_by": null
        },
        {
          "timestamp": "2022-06-13T11:58:54.383341+03:00",
          "state": "canceled",
          "comment": "",
          "cancellation_reason": "canceled",
          "changed_by": {
            "id": 5,
            "first_name": "Tuomas",
            "last_name": "Haapala",
            "email": "tuomas.haapala@anders.fi"
          }
        }
      ]
    }
  ]
}