### PR TITLE
ASU-1554: Fix reservation transfer to another customer

### DIFF
--- a/apartment/tests/api/test_views.py
+++ b/apartment/tests/api/test_views.py
@@ -34,8 +34,8 @@ def test_apartment_list_get_unauthorized(user_api_client):
 
 @pytest.mark.django_db
 @pytest.mark.usefixtures("elastic_apartments")
-def test_apartment_list_get(drupal_salesperson_api_client):
-    response = drupal_salesperson_api_client.get(
+def test_apartment_list_get(sales_ui_salesperson_api_client):
+    response = sales_ui_salesperson_api_client.get(
         reverse("apartment:apartment-list"), format="json"
     )
     assert response.status_code == 200
@@ -44,11 +44,11 @@ def test_apartment_list_get(drupal_salesperson_api_client):
 
 @pytest.mark.django_db
 def test_apartment_list_get_with_project_uuid(
-    drupal_salesperson_api_client, elastic_project_with_5_apartments
+    sales_ui_salesperson_api_client, elastic_project_with_5_apartments
 ):
     project_uuid, apartments = elastic_project_with_5_apartments
     data = {"project_uuid": project_uuid}
-    response = drupal_salesperson_api_client.get(
+    response = sales_ui_salesperson_api_client.get(
         reverse("apartment:apartment-list"),
         data=data,
         format="json",
@@ -67,8 +67,8 @@ def test_project_list_get_unauthorized(user_api_client):
 
 @pytest.mark.django_db
 @pytest.mark.usefixtures("elastic_apartments")
-def test_project_list_get(drupal_salesperson_api_client):
-    response = drupal_salesperson_api_client.get(
+def test_project_list_get(sales_ui_salesperson_api_client):
+    response = sales_ui_salesperson_api_client.get(
         reverse("apartment:project-list"), format="json"
     )
     assert response.status_code == 200
@@ -78,7 +78,7 @@ def test_project_list_get(drupal_salesperson_api_client):
 @pytest.mark.django_db
 @pytest.mark.parametrize("lottery_exists", (True, False))
 def test_project_detail_lottery_completed_at_field(
-    drupal_salesperson_api_client, elastic_project_with_5_apartments, lottery_exists
+    sales_ui_salesperson_api_client, elastic_project_with_5_apartments, lottery_exists
 ):
     project_uuid, apartments = elastic_project_with_5_apartments
 
@@ -89,7 +89,7 @@ def test_project_detail_lottery_completed_at_field(
         "apartment:project-detail",
         kwargs={"project_uuid": project_uuid},
     )
-    response = drupal_salesperson_api_client.get(url, format="json")
+    response = sales_ui_salesperson_api_client.get(url, format="json")
     assert response.status_code == 200
 
     assert response.data["lottery_completed_at"] == (
@@ -100,7 +100,9 @@ def test_project_detail_lottery_completed_at_field(
 @pytest.mark.django_db
 @pytest.mark.parametrize("applications_exist", (True, False))
 def test_project_detail_application_count_field(
-    drupal_salesperson_api_client, elastic_project_with_5_apartments, applications_exist
+    sales_ui_salesperson_api_client,
+    elastic_project_with_5_apartments,
+    applications_exist,
 ):
     project_uuid, apartments = elastic_project_with_5_apartments
 
@@ -125,7 +127,7 @@ def test_project_detail_application_count_field(
         "apartment:project-detail",
         kwargs={"project_uuid": project_uuid},
     )
-    response = drupal_salesperson_api_client.get(url, format="json")
+    response = sales_ui_salesperson_api_client.get(url, format="json")
     assert response.status_code == 200
 
     assert response.data["application_count"] == (2 if applications_exist else 0)
@@ -145,10 +147,10 @@ def test_project_get_with_project_uuid_unauthorized(
 
 @pytest.mark.django_db
 def test_project_get_with_project_uuid(
-    drupal_salesperson_api_client, elastic_project_with_5_apartments
+    sales_ui_salesperson_api_client, elastic_project_with_5_apartments
 ):
     project_uuid, _ = elastic_project_with_5_apartments
-    response = drupal_salesperson_api_client.get(
+    response = sales_ui_salesperson_api_client.get(
         reverse("apartment:project-detail", kwargs={"project_uuid": project_uuid}),
         format="json",
     )
@@ -161,8 +163,8 @@ def test_project_get_with_project_uuid(
 
 
 @pytest.mark.django_db
-def test_project_get_with_project_uuid_not_exist(drupal_salesperson_api_client):
-    response = drupal_salesperson_api_client.get(
+def test_project_get_with_project_uuid_not_exist(sales_ui_salesperson_api_client):
+    response = sales_ui_salesperson_api_client.get(
         reverse("apartment:project-detail", kwargs={"project_uuid": uuid.uuid4()}),
         format="json",
     )
@@ -185,7 +187,7 @@ def _assert_apartment_reservations_data(reservations):
 
 @pytest.mark.django_db
 def test_project_detail_apartment_reservations(
-    drupal_salesperson_api_client, elastic_project_with_5_apartments
+    sales_ui_salesperson_api_client, elastic_project_with_5_apartments
 ):
     expect_apartments_count = 5
     expect_reservations_per_apartment_count = 5
@@ -199,7 +201,7 @@ def test_project_detail_apartment_reservations(
                 state=ApartmentReservationState.SUBMITTED,
             )
 
-    response = drupal_salesperson_api_client.get(
+    response = sales_ui_salesperson_api_client.get(
         reverse("apartment:project-detail", kwargs={"project_uuid": project_uuid}),
         format="json",
     )
@@ -239,7 +241,7 @@ def test_project_detail_apartment_reservations(
 
 @pytest.mark.django_db
 def test_project_detail_apartment_reservations_has_children(
-    drupal_salesperson_api_client, elastic_project_with_5_apartments
+    sales_ui_salesperson_api_client, elastic_project_with_5_apartments
 ):
     expect_apartments_count = 5
 
@@ -256,7 +258,7 @@ def test_project_detail_apartment_reservations_has_children(
             application_apartment=None,
             state=ApartmentReservationState.SUBMITTED,
         )
-    response = drupal_salesperson_api_client.get(
+    response = sales_ui_salesperson_api_client.get(
         reverse("apartment:project-detail", kwargs={"project_uuid": project_uuid}),
         format="json",
     )
@@ -275,7 +277,7 @@ def test_project_detail_apartment_reservations_has_children(
 
 @pytest.mark.django_db
 def test_project_detail_apartment_reservations_multiple_winning(
-    drupal_salesperson_api_client, elastic_project_with_5_apartments
+    sales_ui_salesperson_api_client, elastic_project_with_5_apartments
 ):
     project_uuid, apartments = elastic_project_with_5_apartments
     customer = CustomerFactory()
@@ -296,7 +298,7 @@ def test_project_detail_apartment_reservations_multiple_winning(
     add_application_to_queues(app1)
     add_application_to_queues(app2)
     distribute_apartments(project_uuid)
-    response = drupal_salesperson_api_client.get(
+    response = sales_ui_salesperson_api_client.get(
         reverse("apartment:project-detail", kwargs={"project_uuid": project_uuid}),
         format="json",
     )
@@ -325,7 +327,7 @@ def test_export_applicants_csv_per_project_unauthorized(
 
 @pytest.mark.django_db
 def test_export_applicants_csv_per_project(
-    drupal_salesperson_api_client, elastic_project_with_5_apartments
+    sales_ui_salesperson_api_client, elastic_project_with_5_apartments
 ):
     """
     Test export applicants information to CSV
@@ -334,14 +336,14 @@ def test_export_applicants_csv_per_project(
     project = get_project(project_uuid)
 
     data = {"project_uuid": uuid.uuid4()}
-    response = drupal_salesperson_api_client.get(
+    response = sales_ui_salesperson_api_client.get(
         reverse("apartment:project-detail-export-applicant", kwargs=data),
         format="json",
     )
     assert response.status_code == 404
 
     data = {"project_uuid": project_uuid}
-    response = drupal_salesperson_api_client.get(
+    response = sales_ui_salesperson_api_client.get(
         reverse("apartment:project-detail-export-applicant", kwargs=data),
         format="json",
     )
@@ -377,7 +379,7 @@ def test_export_lottery_result_csv_per_project_unauthorized(
 
 @pytest.mark.django_db
 def test_export_lottery_result_csv_per_project(
-    drupal_salesperson_api_client, elastic_project_with_5_apartments
+    sales_ui_salesperson_api_client, elastic_project_with_5_apartments
 ):
     """
     Test export applicants information to CSV
@@ -386,14 +388,14 @@ def test_export_lottery_result_csv_per_project(
     project = get_project(project_uuid)
 
     data = {"project_uuid": uuid.uuid4()}
-    response = drupal_salesperson_api_client.get(
+    response = sales_ui_salesperson_api_client.get(
         reverse("apartment:project-detail-lottery-result", kwargs=data),
         format="json",
     )
     assert response.status_code == 404
 
     data = {"project_uuid": project_uuid}
-    response = drupal_salesperson_api_client.get(
+    response = sales_ui_salesperson_api_client.get(
         reverse("apartment:project-detail-lottery-result", kwargs=data),
         format="json",
     )
@@ -406,7 +408,7 @@ def test_export_lottery_result_csv_per_project(
     )
     add_application_to_queues(app)
     distribute_apartments(project_uuid)
-    response = drupal_salesperson_api_client.get(
+    response = sales_ui_salesperson_api_client.get(
         reverse("apartment:project-detail-lottery-result", kwargs=data),
         format="json",
     )
@@ -420,7 +422,7 @@ def test_export_lottery_result_csv_per_project(
 
 @pytest.mark.django_db
 def test_project_detail_apartment_states(
-    drupal_salesperson_api_client, elastic_project_with_5_apartments
+    sales_ui_salesperson_api_client, elastic_project_with_5_apartments
 ):
     project_uuid, apartments = elastic_project_with_5_apartments
     apartments = sorted(apartments, key=lambda x: x["uuid"])
@@ -481,7 +483,7 @@ def test_project_detail_apartment_states(
     )
     LotteryEventFactory(apartment_uuid=apartments[4].uuid)
 
-    response = drupal_salesperson_api_client.get(
+    response = sales_ui_salesperson_api_client.get(
         reverse("apartment:project-detail", kwargs={"project_uuid": project_uuid}),
         format="json",
     )
@@ -502,7 +504,7 @@ def test_project_detail_apartment_states(
 
 @pytest.mark.django_db
 def test_project_detail_apartment_reservations_has_cancellation_info(
-    drupal_salesperson_api_client, elastic_project_with_5_apartments
+    sales_ui_salesperson_api_client, elastic_project_with_5_apartments
 ):
     expect_apartments_count = 5
 
@@ -523,7 +525,7 @@ def test_project_detail_apartment_reservations_has_cancellation_info(
             cancellation_reason=ApartmentReservationCancellationReason.CANCELED.value,
         )
 
-    response = drupal_salesperson_api_client.get(
+    response = sales_ui_salesperson_api_client.get(
         reverse("apartment:project-detail", kwargs={"project_uuid": project_uuid}),
         format="json",
     )
@@ -557,14 +559,14 @@ def test_export_sale_report_unauthorized(
 
 @pytest.mark.django_db
 def test_export_sale_report(
-    drupal_salesperson_api_client, elastic_project_with_5_apartments
+    sales_ui_salesperson_api_client, elastic_project_with_5_apartments
 ):
     """
     Test export applicants information to CSV
     """
     project_uuid, apartments = elastic_project_with_5_apartments
 
-    response = drupal_salesperson_api_client.get(
+    response = sales_ui_salesperson_api_client.get(
         reverse("apartment:sale-report"),
         format="json",
     )
@@ -575,7 +577,7 @@ def test_export_sale_report(
         "start_date": "1990-22-12",
         "end_date": "1990-22-12",
     }
-    response = drupal_salesperson_api_client.get(
+    response = sales_ui_salesperson_api_client.get(
         _build_url_with_query_params(base_url, query_params), format="json"
     )
     assert response.status_code == 400
@@ -585,7 +587,7 @@ def test_export_sale_report(
         "start_date": "1990-02-12",
         "end_date": "1990-01-12",
     }
-    response = drupal_salesperson_api_client.get(
+    response = sales_ui_salesperson_api_client.get(
         _build_url_with_query_params(base_url, query_params), format="json"
     )
     assert response.status_code == 400
@@ -595,7 +597,7 @@ def test_export_sale_report(
         "start_date": "2020-02-12",
         "end_date": "2020-03-12",
     }
-    response = drupal_salesperson_api_client.get(
+    response = sales_ui_salesperson_api_client.get(
         _build_url_with_query_params(base_url, query_params), format="json"
     )
     assert response.headers["Content-Type"] == "text/csv; charset=utf-8-sig"
@@ -622,7 +624,7 @@ def test_get_project_extra_data_endpoint_unauthorized(user_api_client):
 @pytest.mark.django_db
 @pytest.mark.parametrize("has_extra_data_instance", (False, True))
 def test_get_project_extra_data_endpoint(
-    drupal_salesperson_api_client, has_extra_data_instance
+    sales_ui_salesperson_api_client, has_extra_data_instance
 ):
     apartment = ApartmentDocumentFactory()
     project_uuid = apartment.project_uuid
@@ -638,7 +640,7 @@ def test_get_project_extra_data_endpoint(
         "apartment:project-detail-extra-data", kwargs={"project_uuid": project_uuid}
     )
 
-    response = drupal_salesperson_api_client.get(url, format="json")
+    response = sales_ui_salesperson_api_client.get(url, format="json")
     assert response.status_code == 200
     expected = (
         {"offer_message_intro": "test intro", "offer_message_content": "test content"}
@@ -669,7 +671,7 @@ def test_put_project_extra_data_endpoint_unauthorized(user_api_client):
 @pytest.mark.django_db
 @pytest.mark.parametrize("has_extra_data_instance", (False, True))
 def test_put_project_extra_data_endpoint(
-    drupal_salesperson_api_client, has_extra_data_instance
+    sales_ui_salesperson_api_client, has_extra_data_instance
 ):
     apartment = ApartmentDocumentFactory()
     project_uuid = apartment.project_uuid
@@ -690,7 +692,7 @@ def test_put_project_extra_data_endpoint(
         "apartment:project-detail-extra-data", kwargs={"project_uuid": project_uuid}
     )
 
-    response = drupal_salesperson_api_client.put(url, data=data, format="json")
+    response = sales_ui_salesperson_api_client.put(url, data=data, format="json")
     assert response.status_code == 200
     assert response.data == {
         "offer_message_intro": "updated test intro",
@@ -703,13 +705,13 @@ def test_put_project_extra_data_endpoint(
 
 @pytest.mark.django_db
 def test_get_project_extra_data_endpoint_non_existing_project(
-    drupal_salesperson_api_client,
+    sales_ui_salesperson_api_client,
 ):
     ApartmentDocumentFactory()
     project_uuid = uuid.uuid4()
 
     url = reverse("apartment:project-detail", kwargs={"project_uuid": project_uuid})
-    response = drupal_salesperson_api_client.get(url, format="json")
+    response = sales_ui_salesperson_api_client.get(url, format="json")
 
     assert response.status_code == 404
 
@@ -717,7 +719,7 @@ def test_get_project_extra_data_endpoint_non_existing_project(
 @pytest.mark.django_db
 @pytest.mark.parametrize("has_extra_data_instance", (False, True))
 def test_get_project_detail_extra_data_field(
-    drupal_salesperson_api_client, has_extra_data_instance
+    sales_ui_salesperson_api_client, has_extra_data_instance
 ):
     apartment = ApartmentDocumentFactory()
     project_uuid = apartment.project_uuid
@@ -731,7 +733,7 @@ def test_get_project_detail_extra_data_field(
 
     url = reverse("apartment:project-detail", kwargs={"project_uuid": project_uuid})
 
-    response = drupal_salesperson_api_client.get(url, format="json")
+    response = sales_ui_salesperson_api_client.get(url, format="json")
     assert response.status_code == 200
     expected = (
         {"offer_message_intro": "test intro", "offer_message_content": "test content"}

--- a/apartment/tests/conftest.py
+++ b/apartment/tests/conftest.py
@@ -7,8 +7,8 @@ from pytest import fixture
 from apartment.tests.factories import ApartmentDocumentFactory
 from users.tests.conftest import (  # noqa: F401
     api_client,
-    sales_ui_salesperson_api_client,
     profile_api_client,
+    sales_ui_salesperson_api_client,
     user_api_client,
 )
 

--- a/apartment/tests/conftest.py
+++ b/apartment/tests/conftest.py
@@ -7,7 +7,7 @@ from pytest import fixture
 from apartment.tests.factories import ApartmentDocumentFactory
 from users.tests.conftest import (  # noqa: F401
     api_client,
-    drupal_salesperson_api_client,
+    sales_ui_salesperson_api_client,
     profile_api_client,
     user_api_client,
 )

--- a/application_form/services/reservation.py
+++ b/application_form/services/reservation.py
@@ -35,7 +35,7 @@ def transfer_reservation_to_another_customer(
         list_position=old_reservation.list_position + 1,
         state=old_reservation.state,
         customer=customer,
-        handler=user.profile.full_name,
+        handler=user.full_name,
     )
 
     # Shift reservations after the old reservation one step back to make room for the

--- a/application_form/tests/api/test_apartment_reservation_api.py
+++ b/application_form/tests/api/test_apartment_reservation_api.py
@@ -54,7 +54,7 @@ def test_root_apartment_reservation_detail_unauthorized(
 
 @pytest.mark.django_db
 def test_root_apartment_reservation_detail(
-    drupal_salesperson_api_client, elastic_project_with_5_apartments
+    sales_ui_salesperson_api_client, elastic_project_with_5_apartments
 ):
     _, apartments = elastic_project_with_5_apartments
     reservation = ApartmentReservationFactory(
@@ -63,7 +63,7 @@ def test_root_apartment_reservation_detail(
     installment = ApartmentInstallmentFactory(apartment_reservation=reservation)
     offer = OfferFactory(apartment_reservation=reservation)
 
-    response = drupal_salesperson_api_client.get(
+    response = sales_ui_salesperson_api_client.get(
         reverse(
             "application_form:sales-apartment-reservation-detail",
             kwargs={"pk": reservation.id},
@@ -110,7 +110,7 @@ def test_root_apartment_reservation_detail(
 
 @pytest.mark.django_db
 def test_root_apartment_reservation_detail_installment_candidates(
-    drupal_salesperson_api_client,
+    sales_ui_salesperson_api_client,
 ):
     apartment = ApartmentDocumentFactory(
         sales_price=12345678, debt_free_sales_price=9876543  # 123456,78e and 98765,43e
@@ -157,7 +157,7 @@ def test_root_apartment_reservation_detail_installment_candidates(
         due_date=None,
     )
 
-    response = drupal_salesperson_api_client.get(
+    response = sales_ui_salesperson_api_client.get(
         reverse(
             "application_form:sales-apartment-reservation-detail",
             kwargs={"pk": reservation.id},
@@ -218,7 +218,7 @@ def test_contract_pdf_creation_unauthorized(user_api_client):
 @pytest.mark.parametrize("ownership_type", ("HASO", "Hitas"))
 @pytest.mark.django_db
 def test_contract_pdf_creation(
-    drupal_salesperson_api_client, ownership_type, reservation_has_application
+    sales_ui_salesperson_api_client, ownership_type, reservation_has_application
 ):
     apartment = ApartmentDocumentFactory(project_ownership_type=ownership_type)
 
@@ -229,7 +229,7 @@ def test_contract_pdf_creation(
             apartment_uuid=apartment.uuid, application_apartment=None
         )
 
-    response = drupal_salesperson_api_client.get(
+    response = sales_ui_salesperson_api_client.get(
         reverse(
             "application_form:sales-apartment-reservation-contract",
             kwargs={"pk": reservation.id},
@@ -269,14 +269,14 @@ def test_apartment_reservation_set_state_unauthorized(user_api_client):
 
 @pytest.mark.parametrize("comment", ("Foo", ""))
 @pytest.mark.django_db
-def test_apartment_reservation_set_state(drupal_salesperson_api_client, comment):
+def test_apartment_reservation_set_state(sales_ui_salesperson_api_client, comment):
     apartment = ApartmentDocumentFactory()
     reservation = ApartmentReservationFactory(
         apartment_uuid=apartment.uuid, state=ApartmentReservationState.SUBMITTED
     )
 
     data = {"state": "reserved", "comment": comment}
-    response = drupal_salesperson_api_client.post(
+    response = sales_ui_salesperson_api_client.post(
         reverse(
             "application_form:sales-apartment-reservation-set-state",
             kwargs={"pk": reservation.id},
@@ -288,7 +288,7 @@ def test_apartment_reservation_set_state(drupal_salesperson_api_client, comment)
 
     assert response.data.pop("timestamp")
 
-    user = drupal_salesperson_api_client.user
+    user = sales_ui_salesperson_api_client.user
     assert response.data == {
         "state": "reserved",
         "comment": comment,
@@ -306,7 +306,7 @@ def test_apartment_reservation_set_state(drupal_salesperson_api_client, comment)
     assert state_change_event.timestamp
     assert state_change_event.state == ApartmentReservationState.RESERVED
     assert state_change_event.comment == comment
-    assert state_change_event.user == drupal_salesperson_api_client.user
+    assert state_change_event.user == sales_ui_salesperson_api_client.user
 
 
 @pytest.mark.django_db
@@ -330,14 +330,16 @@ def test_apartment_reservation_canceling_unauthorized(user_api_client):
 
 @pytest.mark.parametrize("ownership_type", ("Haso", "Puolihitas", "Hitas"))
 @pytest.mark.django_db
-def test_apartment_reservation_canceling(drupal_salesperson_api_client, ownership_type):
+def test_apartment_reservation_canceling(
+    sales_ui_salesperson_api_client, ownership_type
+):
     apartment = ApartmentDocumentFactory(project_ownership_type=ownership_type)
     reservation = ApartmentReservationFactory(
         apartment_uuid=apartment.uuid, state=ApartmentReservationState.SUBMITTED
     )
 
     data = {"cancellation_reason": "terminated", "comment": "Foo"}
-    response = drupal_salesperson_api_client.post(
+    response = sales_ui_salesperson_api_client.post(
         reverse(
             "application_form:sales-apartment-reservation-cancel",
             kwargs={"pk": reservation.id},
@@ -360,12 +362,12 @@ def test_apartment_reservation_canceling(drupal_salesperson_api_client, ownershi
     assert state_change_event.timestamp
     assert state_change_event.state == ApartmentReservationState.CANCELED
     assert state_change_event.cancellation_reason
-    assert state_change_event.user == drupal_salesperson_api_client.user
+    assert state_change_event.user == sales_ui_salesperson_api_client.user
 
 
 @pytest.mark.django_db
 def test_cannot_cancel_already_canceled_apartment_reservation(
-    drupal_salesperson_api_client,
+    sales_ui_salesperson_api_client,
 ):
     apartment = ApartmentDocumentFactory()
     reservation = ApartmentReservationFactory(
@@ -375,7 +377,7 @@ def test_cannot_cancel_already_canceled_apartment_reservation(
     )
 
     data = {"cancellation_reason": "terminated", "comment": "Foo"}
-    response = drupal_salesperson_api_client.post(
+    response = sales_ui_salesperson_api_client.post(
         reverse(
             "application_form:sales-apartment-reservation-cancel",
             kwargs={"pk": reservation.id},
@@ -389,7 +391,7 @@ def test_cannot_cancel_already_canceled_apartment_reservation(
 
 @pytest.mark.django_db
 def test_apartment_reservation_cancellation_reason_validation(
-    drupal_salesperson_api_client,
+    sales_ui_salesperson_api_client,
 ):
     apartment = ApartmentDocumentFactory()
     reservation = ApartmentReservationFactory(
@@ -397,7 +399,7 @@ def test_apartment_reservation_cancellation_reason_validation(
     )
 
     data = {"comment": "Foo"}
-    response = drupal_salesperson_api_client.post(
+    response = sales_ui_salesperson_api_client.post(
         reverse(
             "application_form:sales-apartment-reservation-cancel",
             kwargs={"pk": reservation.id},
@@ -411,7 +413,7 @@ def test_apartment_reservation_cancellation_reason_validation(
 
 @pytest.mark.django_db
 def test_apartment_reservation_hide_queue_position(
-    drupal_salesperson_api_client, elastic_hitas_project_with_5_apartments
+    sales_ui_salesperson_api_client, elastic_hitas_project_with_5_apartments
 ):
     project_uuid, apartments = elastic_hitas_project_with_5_apartments
     first_apartment_uuid = apartments[0].uuid
@@ -421,7 +423,7 @@ def test_apartment_reservation_hide_queue_position(
     )
     add_application_to_queues(app)
 
-    response = drupal_salesperson_api_client.get(
+    response = sales_ui_salesperson_api_client.get(
         reverse(
             "application_form:sales-apartment-reservation-detail",
             kwargs={"pk": app_apartment.apartment_reservation.id},
@@ -434,7 +436,7 @@ def test_apartment_reservation_hide_queue_position(
 
     distribute_apartments(project_uuid)
 
-    response = drupal_salesperson_api_client.get(
+    response = sales_ui_salesperson_api_client.get(
         reverse(
             "application_form:sales-apartment-reservation-detail",
             kwargs={"pk": app_apartment.apartment_reservation.id},
@@ -447,7 +449,7 @@ def test_apartment_reservation_hide_queue_position(
 
 
 @pytest.mark.django_db
-def test_transfer_reservation_to_another_customer(drupal_salesperson_api_client):
+def test_transfer_reservation_to_another_customer(sales_ui_salesperson_api_client):
     apartment = ApartmentDocumentFactory()
     customer = CustomerFactory()
     another_customer = CustomerFactory()
@@ -480,7 +482,7 @@ def test_transfer_reservation_to_another_customer(drupal_salesperson_api_client)
         customer=customer,
     )
 
-    response = drupal_salesperson_api_client.post(
+    response = sales_ui_salesperson_api_client.post(
         reverse(
             "application_form:sales-apartment-reservation-cancel",
             kwargs={"pk": reservation_2.id},
@@ -539,7 +541,7 @@ def test_transfer_reservation_to_another_customer(drupal_salesperson_api_client)
 
 @pytest.mark.django_db
 def test_transferring_apartment_reservation_requires_customer(
-    drupal_salesperson_api_client,
+    sales_ui_salesperson_api_client,
 ):
     apartment = ApartmentDocumentFactory()
     reservation = ApartmentReservationFactory(
@@ -548,7 +550,7 @@ def test_transferring_apartment_reservation_requires_customer(
     )
 
     data = {"cancellation_reason": "transferred", "comment": "Foo"}
-    response = drupal_salesperson_api_client.post(
+    response = sales_ui_salesperson_api_client.post(
         reverse(
             "application_form:sales-apartment-reservation-cancel",
             kwargs={"pk": reservation.id},
@@ -584,7 +586,7 @@ def test_create_reservation_unauthorized(user_api_client):
 
 @pytest.mark.parametrize("include_read_only_fields", (False, True))
 @pytest.mark.django_db
-def test_create_reservation(drupal_salesperson_api_client, include_read_only_fields):
+def test_create_reservation(sales_ui_salesperson_api_client, include_read_only_fields):
     apartment = ApartmentDocumentFactory()
     customer = CustomerFactory(
         right_of_residence=777,
@@ -615,7 +617,7 @@ def test_create_reservation(drupal_salesperson_api_client, include_read_only_fie
             }
         )
 
-    response = drupal_salesperson_api_client.post(
+    response = sales_ui_salesperson_api_client.post(
         reverse(
             "application_form:sales-apartment-reservation-list",
         ),
@@ -657,11 +659,11 @@ def test_create_reservation(drupal_salesperson_api_client, include_read_only_fie
     state_change_event = reservation.state_change_events.first()
     assert state_change_event.state == ApartmentReservationState.RESERVED
     assert state_change_event.timestamp
-    assert state_change_event.user == drupal_salesperson_api_client.user
+    assert state_change_event.user == sales_ui_salesperson_api_client.user
 
 
 @pytest.mark.django_db
-def test_create_reservation_lottery_not_executed(drupal_salesperson_api_client):
+def test_create_reservation_lottery_not_executed(sales_ui_salesperson_api_client):
     apartment = ApartmentDocumentFactory()
     customer = CustomerFactory()
 
@@ -670,7 +672,7 @@ def test_create_reservation_lottery_not_executed(drupal_salesperson_api_client):
         "customer_id": customer.id,
     }
 
-    response = drupal_salesperson_api_client.post(
+    response = sales_ui_salesperson_api_client.post(
         reverse(
             "application_form:sales-apartment-reservation-list",
         ),
@@ -684,7 +686,7 @@ def test_create_reservation_lottery_not_executed(drupal_salesperson_api_client):
 
 @pytest.mark.django_db
 def test_create_reservation_lottery_non_existing_apartment(
-    drupal_salesperson_api_client,
+    sales_ui_salesperson_api_client,
 ):
     apartment = ApartmentDocumentFactory()
     customer = CustomerFactory()
@@ -695,7 +697,7 @@ def test_create_reservation_lottery_non_existing_apartment(
         "customer_id": customer.id,
     }
 
-    response = drupal_salesperson_api_client.post(
+    response = sales_ui_salesperson_api_client.post(
         reverse(
             "application_form:sales-apartment-reservation-list",
         ),
@@ -709,7 +711,7 @@ def test_create_reservation_lottery_non_existing_apartment(
 
 @pytest.mark.django_db
 def test_create_reservation_queue_already_has_canceled_reservation(
-    drupal_salesperson_api_client,
+    sales_ui_salesperson_api_client,
 ):
     apartment = ApartmentDocumentFactory()
     customer = CustomerFactory()
@@ -726,7 +728,7 @@ def test_create_reservation_queue_already_has_canceled_reservation(
         "customer_id": customer.id,
     }
 
-    response = drupal_salesperson_api_client.post(
+    response = sales_ui_salesperson_api_client.post(
         reverse(
             "application_form:sales-apartment-reservation-list",
         ),
@@ -741,7 +743,7 @@ def test_create_reservation_queue_already_has_canceled_reservation(
 
 @pytest.mark.django_db
 def test_create_reservation_queue_already_has_reserved_reservation(
-    drupal_salesperson_api_client,
+    sales_ui_salesperson_api_client,
 ):
     apartment = ApartmentDocumentFactory()
     customer = CustomerFactory()
@@ -758,7 +760,7 @@ def test_create_reservation_queue_already_has_reserved_reservation(
         "customer_id": customer.id,
     }
 
-    response = drupal_salesperson_api_client.post(
+    response = sales_ui_salesperson_api_client.post(
         reverse(
             "application_form:sales-apartment-reservation-list",
         ),
@@ -790,7 +792,7 @@ def test_get_offer_message_unauthorized(user_api_client):
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("ownership_type", ["puolihitas", "hitas", "haso"])
-def test_get_offer_message(drupal_salesperson_api_client, ownership_type):
+def test_get_offer_message(sales_ui_salesperson_api_client, ownership_type):
     apartment = ApartmentDocumentFactory(
         apartment_number="A1",
         apartment_structure="5h+k",
@@ -827,7 +829,7 @@ def test_get_offer_message(drupal_salesperson_api_client, ownership_type):
         "application_form:sales-apartment-reservation-offer-message",
         kwargs={"pk": reservation.id},
     ) + ("?valid_until=2022-03-04" if ownership_type == "haso" else "")
-    response = drupal_salesperson_api_client.get(url)
+    response = sales_ui_salesperson_api_client.get(url)
     assert response.status_code == 200
 
     expected_subject = "Tarjous As Oy Pojanlohi A1"
@@ -899,7 +901,7 @@ content
     )
     reservation.customer.save()
 
-    response = drupal_salesperson_api_client.get(url)
+    response = sales_ui_salesperson_api_client.get(url)
     assert response.status_code == 200
 
     expected_data["recipients"].append(

--- a/application_form/tests/api/test_offer_api.py
+++ b/application_form/tests/api/test_offer_api.py
@@ -85,7 +85,7 @@ def test_create_offer(sales_ui_salesperson_api_client):
 
 
 @pytest.mark.django_db
-def test_create_offer_already_exists(drupal_salesperson_api_client):
+def test_create_offer_already_exists(sales_ui_salesperson_api_client):
     apartment = ApartmentDocumentFactory()
     reservation = ApartmentReservationFactory(apartment_uuid=apartment.uuid)
     week_in_future = timezone.localdate() + timedelta(days=7)
@@ -102,7 +102,7 @@ def test_create_offer_already_exists(drupal_salesperson_api_client):
         concluded_at=timezone.now(),
     )
 
-    response = drupal_salesperson_api_client.post(
+    response = sales_ui_salesperson_api_client.post(
         reverse(
             "application_form:sales-offer-list",
         ),
@@ -142,7 +142,7 @@ def test_update_offer_unauthorized(user_api_client):
 
 
 @pytest.mark.django_db
-def test_update_offer(drupal_salesperson_api_client):
+def test_update_offer(sales_ui_salesperson_api_client):
     today = timezone.localdate()
     apartment = ApartmentDocumentFactory()
     reservation = ApartmentReservationFactory(apartment_uuid=apartment.uuid)
@@ -157,7 +157,7 @@ def test_update_offer(drupal_salesperson_api_client):
         "comment": "new comment",
     }
 
-    response = drupal_salesperson_api_client.patch(
+    response = sales_ui_salesperson_api_client.patch(
         reverse(
             "application_form:sales-offer-detail",
             kwargs={"pk": offer.pk},
@@ -187,7 +187,7 @@ def test_update_offer(drupal_salesperson_api_client):
 
 @pytest.mark.parametrize("new_state", ("accepted", "rejected"))
 @pytest.mark.django_db
-def test_update_offer_change_state(drupal_salesperson_api_client, new_state):
+def test_update_offer_change_state(sales_ui_salesperson_api_client, new_state):
     apartment = ApartmentDocumentFactory()
     reservation = ApartmentReservationFactory(
         apartment_uuid=apartment.uuid,
@@ -208,7 +208,7 @@ def test_update_offer_change_state(drupal_salesperson_api_client, new_state):
 
     data = {"state": new_state}
 
-    response = drupal_salesperson_api_client.patch(
+    response = sales_ui_salesperson_api_client.patch(
         reverse(
             "application_form:sales-offer-detail",
             kwargs={"pk": offer.pk},
@@ -238,7 +238,7 @@ def test_update_offer_change_state(drupal_salesperson_api_client, new_state):
 @pytest.mark.parametrize("state", ("accepted", "rejected"))
 @pytest.mark.django_db
 def test_cannot_update_concluded_offer_valid_until_or_state(
-    drupal_salesperson_api_client, state
+    sales_ui_salesperson_api_client, state
 ):
     apartment = ApartmentDocumentFactory()
     reservation = ApartmentReservationFactory(apartment_uuid=apartment.uuid)
@@ -256,7 +256,7 @@ def test_cannot_update_concluded_offer_valid_until_or_state(
             "state": "accepted" if state == "rejected" else "rejected",
         },
     ):
-        response = drupal_salesperson_api_client.patch(
+        response = sales_ui_salesperson_api_client.patch(
             reverse(
                 "application_form:sales-offer-detail",
                 kwargs={"pk": offer.pk},
@@ -270,7 +270,7 @@ def test_cannot_update_concluded_offer_valid_until_or_state(
 
 @pytest.mark.parametrize("state", ("accepted", "rejected"))
 @pytest.mark.django_db
-def test_update_concluded_offer_comment(drupal_salesperson_api_client, state):
+def test_update_concluded_offer_comment(sales_ui_salesperson_api_client, state):
     apartment = ApartmentDocumentFactory()
     reservation = ApartmentReservationFactory(apartment_uuid=apartment.uuid)
     another_reservation = ApartmentReservationFactory(
@@ -294,7 +294,7 @@ def test_update_concluded_offer_comment(drupal_salesperson_api_client, state):
         "apartment_reservation_id": another_reservation.id,
     }
 
-    response = drupal_salesperson_api_client.put(
+    response = sales_ui_salesperson_api_client.put(
         reverse(
             "application_form:sales-offer-detail",
             kwargs={"pk": offer.pk},
@@ -312,7 +312,7 @@ def test_update_concluded_offer_comment(drupal_salesperson_api_client, state):
 
 
 @pytest.mark.django_db
-def test_update_offer_change_to_expired(drupal_salesperson_api_client):
+def test_update_offer_change_to_expired(sales_ui_salesperson_api_client):
     today = timezone.localdate()
     apartment = ApartmentDocumentFactory()
     reservation = ApartmentReservationFactory(
@@ -326,7 +326,7 @@ def test_update_offer_change_to_expired(drupal_salesperson_api_client):
 
     data = {"valid_until": str(today - timedelta(days=1))}
 
-    response = drupal_salesperson_api_client.patch(
+    response = sales_ui_salesperson_api_client.patch(
         reverse(
             "application_form:sales-offer-detail",
             kwargs={"pk": offer.pk},
@@ -342,7 +342,7 @@ def test_update_offer_change_to_expired(drupal_salesperson_api_client):
 
 
 @pytest.mark.django_db
-def test_create_offer_cancel_other_reservations(drupal_salesperson_api_client):
+def test_create_offer_cancel_other_reservations(sales_ui_salesperson_api_client):
     apartment_1 = ApartmentDocumentFactory()
     apartment_2 = ApartmentDocumentFactory(project_uuid=apartment_1.project_uuid)
     apartment_3 = ApartmentDocumentFactory(project_uuid=apartment_1.project_uuid)
@@ -380,7 +380,7 @@ def test_create_offer_cancel_other_reservations(drupal_salesperson_api_client):
         == 1
     )
 
-    response = drupal_salesperson_api_client.post(
+    response = sales_ui_salesperson_api_client.post(
         reverse(
             "application_form:sales-offer-list",
         ),

--- a/application_form/tests/test_lottery_api.py
+++ b/application_form/tests/test_lottery_api.py
@@ -15,9 +15,9 @@ from application_form.tests.factories import ApplicationFactory
 @pytest.mark.django_db
 @pytest.mark.usefixtures("elastic_apartments")
 def test_execute_lottery_for_project_post_without_project_uuid(
-    drupal_salesperson_api_client,
+    sales_ui_salesperson_api_client,
 ):
-    response = drupal_salesperson_api_client.post(
+    response = sales_ui_salesperson_api_client.post(
         reverse("application_form:execute_lottery_for_project"), format="json"
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -26,10 +26,10 @@ def test_execute_lottery_for_project_post_without_project_uuid(
 @pytest.mark.django_db
 @pytest.mark.usefixtures("elastic_apartments")
 def test_execute_lottery_for_project_post_badly_formatted_project_uuid(
-    drupal_salesperson_api_client,
+    sales_ui_salesperson_api_client,
 ):
     data = {"project_uuid": "lizard"}
-    response = drupal_salesperson_api_client.post(
+    response = sales_ui_salesperson_api_client.post(
         reverse("application_form:execute_lottery_for_project"), data, format="json"
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -38,7 +38,7 @@ def test_execute_lottery_for_project_post_badly_formatted_project_uuid(
 @pytest.mark.django_db
 @pytest.mark.usefixtures("elastic_apartments")
 def test_execute_lottery_for_project_post_fails_application_time_not_finished(
-    drupal_salesperson_api_client, elastic_project_application_time_active
+    sales_ui_salesperson_api_client, elastic_project_application_time_active
 ):
     project_uuid, apartment = elastic_project_application_time_active
 
@@ -47,7 +47,7 @@ def test_execute_lottery_for_project_post_fails_application_time_not_finished(
     add_application_to_queues(app)
 
     data = {"project_uuid": project_uuid}
-    response = drupal_salesperson_api_client.post(
+    response = sales_ui_salesperson_api_client.post(
         reverse("application_form:execute_lottery_for_project"), data, format="json"
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -58,9 +58,9 @@ def test_execute_lottery_for_project_post_fails_application_time_not_finished(
 
 @pytest.mark.django_db
 @pytest.mark.usefixtures("elastic_apartments")
-def test_execute_lottery_for_project_post_not_found(drupal_salesperson_api_client):
+def test_execute_lottery_for_project_post_not_found(sales_ui_salesperson_api_client):
     data = {"project_uuid": 1234}
-    response = drupal_salesperson_api_client.post(
+    response = sales_ui_salesperson_api_client.post(
         reverse("application_form:execute_lottery_for_project"), data, format="json"
     )
     assert response.status_code == status.HTTP_404_NOT_FOUND
@@ -85,7 +85,7 @@ def test_execute_hitas_lottery_for_project_post_unauthorized(
 
 @pytest.mark.django_db
 def test_execute_hitas_lottery_for_project_post(
-    drupal_salesperson_api_client, elastic_hitas_project_application_end_time_finished
+    sales_ui_salesperson_api_client, elastic_hitas_project_application_end_time_finished
 ):
     project_uuid, apartment = elastic_hitas_project_application_end_time_finished
 
@@ -94,7 +94,7 @@ def test_execute_hitas_lottery_for_project_post(
     add_application_to_queues(app)
 
     data = {"project_uuid": project_uuid}
-    response = drupal_salesperson_api_client.post(
+    response = sales_ui_salesperson_api_client.post(
         reverse("application_form:execute_lottery_for_project"), data, format="json"
     )
     assert response.status_code == status.HTTP_200_OK
@@ -102,12 +102,12 @@ def test_execute_hitas_lottery_for_project_post(
 
 @pytest.mark.django_db
 def test_execute_hitas_lottery_for_project_post_without_applications(
-    drupal_salesperson_api_client, elastic_hitas_project_with_5_apartments
+    sales_ui_salesperson_api_client, elastic_hitas_project_with_5_apartments
 ):
     project_uuid, apartments = elastic_hitas_project_with_5_apartments
 
     data = {"project_uuid": project_uuid}
-    response = drupal_salesperson_api_client.post(
+    response = sales_ui_salesperson_api_client.post(
         reverse("application_form:execute_lottery_for_project"), data, format="json"
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -132,7 +132,7 @@ def test_execute_haso_lottery_for_project_post_unauthorized(
 
 @pytest.mark.django_db
 def test_execute_haso_lottery_for_project_post(
-    drupal_salesperson_api_client, elastic_haso_project_application_end_time_finished
+    sales_ui_salesperson_api_client, elastic_haso_project_application_end_time_finished
 ):
     project_uuid, apartment = elastic_haso_project_application_end_time_finished
 
@@ -141,7 +141,7 @@ def test_execute_haso_lottery_for_project_post(
     add_application_to_queues(app)
 
     data = {"project_uuid": project_uuid}
-    response = drupal_salesperson_api_client.post(
+    response = sales_ui_salesperson_api_client.post(
         reverse("application_form:execute_lottery_for_project"), data, format="json"
     )
     assert response.status_code == status.HTTP_200_OK
@@ -149,12 +149,12 @@ def test_execute_haso_lottery_for_project_post(
 
 @pytest.mark.django_db
 def test_execute_haso_lottery_for_project_post_without_applications(
-    drupal_salesperson_api_client, elastic_haso_project_with_5_apartments
+    sales_ui_salesperson_api_client, elastic_haso_project_with_5_apartments
 ):
     project_uuid, apartments = elastic_haso_project_with_5_apartments
 
     data = {"project_uuid": project_uuid}
-    response = drupal_salesperson_api_client.post(
+    response = sales_ui_salesperson_api_client.post(
         reverse("application_form:execute_lottery_for_project"), data, format="json"
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/customer/tests/api/sales/test_customer_api.py
+++ b/customer/tests/api/sales/test_customer_api.py
@@ -38,7 +38,7 @@ def test_get_customer_api_detail_unauthorized(user_api_client):
 
 
 @pytest.mark.django_db
-def test_get_customer_api_detail(drupal_salesperson_api_client):
+def test_get_customer_api_detail(sales_ui_salesperson_api_client):
     apartment = ApartmentDocumentFactory(
         sales_price=2000,
         debt_free_sales_price=1500,
@@ -57,7 +57,7 @@ def test_get_customer_api_detail(drupal_salesperson_api_client):
         apartment_reservation=reservation, value=100
     )
 
-    response = drupal_salesperson_api_client.get(
+    response = sales_ui_salesperson_api_client.get(
         reverse("customer:sales-customer-detail", args=(customer.pk,)),
         format="json",
     )
@@ -129,7 +129,9 @@ def test_get_customer_api_detail(drupal_salesperson_api_client):
 
 
 @pytest.mark.django_db
-def test_customer_detail_state_event_cancellation_reason(drupal_salesperson_api_client):
+def test_customer_detail_state_event_cancellation_reason(
+    sales_ui_salesperson_api_client,
+):
     apartment = ApartmentDocumentFactory(
         sales_price=2000,
         debt_free_sales_price=1500,
@@ -145,7 +147,7 @@ def test_customer_detail_state_event_cancellation_reason(drupal_salesperson_api_
         cancellation_reason=ApartmentReservationCancellationReason.CANCELED,
     )
 
-    response = drupal_salesperson_api_client.get(
+    response = sales_ui_salesperson_api_client.get(
         reverse("customer:sales-customer-detail", args=(customer.pk,)),
         format="json",
     )
@@ -159,7 +161,7 @@ def test_customer_detail_state_event_cancellation_reason(drupal_salesperson_api_
 
 
 @pytest.mark.django_db
-def test_customer_detail_state_event_changed_by(drupal_salesperson_api_client):
+def test_customer_detail_state_event_changed_by(sales_ui_salesperson_api_client):
     apartment = ApartmentDocumentFactory(
         sales_price=2000,
         debt_free_sales_price=1500,
@@ -179,7 +181,7 @@ def test_customer_detail_state_event_changed_by(drupal_salesperson_api_client):
         user=user,
     )
 
-    response = drupal_salesperson_api_client.get(
+    response = sales_ui_salesperson_api_client.get(
         reverse("customer:sales-customer-detail", args=(customer.pk,)),
         format="json",
     )
@@ -195,13 +197,13 @@ def test_customer_detail_state_event_changed_by(drupal_salesperson_api_client):
 
 
 @pytest.mark.django_db
-def test_get_customer_api_list_without_any_parameters(drupal_salesperson_api_client):
+def test_get_customer_api_list_without_any_parameters(sales_ui_salesperson_api_client):
     CustomerFactory(secondary_profile=None)
     CustomerFactory(secondary_profile=ProfileFactory())
 
     expected_data = []
 
-    response = drupal_salesperson_api_client.get(
+    response = sales_ui_salesperson_api_client.get(
         reverse("customer:sales-customer-list"), format="json"
     )
 
@@ -332,7 +334,7 @@ def test_update_customer(
 
 
 @pytest.mark.django_db
-def test_get_customer_api_list_with_parameters(drupal_salesperson_api_client):
+def test_get_customer_api_list_with_parameters(sales_ui_salesperson_api_client):
     customers = {}
     customer = CustomerFactory(
         primary_profile__first_name="John",
@@ -349,7 +351,7 @@ def test_get_customer_api_list_with_parameters(drupal_salesperson_api_client):
     customers[customer_with_secondary.id] = customer_with_secondary
 
     # Search value is less than min length
-    response = drupal_salesperson_api_client.get(
+    response = sales_ui_salesperson_api_client.get(
         reverse("customer:sales-customer-list"),
         data={
             "last_name": customer.primary_profile.last_name[
@@ -362,7 +364,7 @@ def test_get_customer_api_list_with_parameters(drupal_salesperson_api_client):
     assert response.data == []
 
     # Search value's minimum length has reached
-    response = drupal_salesperson_api_client.get(
+    response = sales_ui_salesperson_api_client.get(
         reverse("customer:sales-customer-list"),
         data={
             "last_name": customer.primary_profile.last_name[
@@ -378,7 +380,7 @@ def test_get_customer_api_list_with_parameters(drupal_salesperson_api_client):
         assert_customer_list_match_data(customers[item["id"]], item)
 
     # Search value with two params
-    response = drupal_salesperson_api_client.get(
+    response = sales_ui_salesperson_api_client.get(
         reverse("customer:sales-customer-list"),
         data={
             "first_name": customer_with_secondary.primary_profile.first_name[
@@ -398,7 +400,7 @@ def test_get_customer_api_list_with_parameters(drupal_salesperson_api_client):
 
 
 @pytest.mark.django_db
-def test_customer_reservation_ordering(drupal_salesperson_api_client):
+def test_customer_reservation_ordering(sales_ui_salesperson_api_client):
     project_uuid = uuid.uuid4()
     apartment_a5 = ApartmentDocumentFactory(
         project_uuid=project_uuid, apartment_number="A5"
@@ -444,7 +446,7 @@ def test_customer_reservation_ordering(drupal_salesperson_api_client):
     ]
     reservation_ids = [r.id for r in reservations]
 
-    response = drupal_salesperson_api_client.get(
+    response = sales_ui_salesperson_api_client.get(
         reverse("customer:sales-customer-detail", kwargs={"pk": customer.pk}),
         format="json",
     )

--- a/customer/tests/conftest.py
+++ b/customer/tests/conftest.py
@@ -1,6 +1,5 @@
 from users.tests.conftest import (  # noqa: F401
     api_client,
-    drupal_salesperson_api_client,
     sales_ui_salesperson_api_client,
     user_api_client,
 )

--- a/invoicing/tests/conftest.py
+++ b/invoicing/tests/conftest.py
@@ -2,7 +2,6 @@ import pytest
 
 from users.tests.conftest import (  # noqa: F401
     api_client,
-    drupal_salesperson_api_client,
     sales_ui_salesperson_api_client,
     user_api_client,
 )

--- a/invoicing/tests/test_api.py
+++ b/invoicing/tests/test_api.py
@@ -47,11 +47,11 @@ def reservation_with_installments():
 
 @pytest.mark.django_db
 def test_project_list_does_not_include_installments(
-    apartment_document, drupal_salesperson_api_client
+    apartment_document, sales_ui_salesperson_api_client
 ):
     ProjectInstallmentTemplateFactory()
 
-    response = drupal_salesperson_api_client.get(
+    response = sales_ui_salesperson_api_client.get(
         reverse("apartment:project-list"), format="json"
     )
     assert response.status_code == 200
@@ -114,7 +114,7 @@ def test_project_detail_installments_field_and_endpoint_data_unauthorized(
     ],
 )
 def test_project_detail_installments_field_and_installments_endpoint_data(
-    apartment_document, drupal_salesperson_api_client, target
+    apartment_document, sales_ui_salesperson_api_client, target
 ):
     project_uuid = apartment_document.project_uuid
     ProjectInstallmentTemplateFactory(
@@ -147,7 +147,7 @@ def test_project_detail_installments_field_and_installments_endpoint_data(
             kwargs={"project_uuid": project_uuid},
         )
 
-    response = drupal_salesperson_api_client.get(url, format="json")
+    response = sales_ui_salesperson_api_client.get(url, format="json")
     assert response.status_code == 200
 
     if target == "field":
@@ -205,7 +205,7 @@ def test_set_project_installments_unauthorized(apartment_document, user_api_clie
 @pytest.mark.parametrize("has_old_installments", (False, True))
 @pytest.mark.django_db
 def test_set_project_installments(
-    apartment_document, drupal_salesperson_api_client, has_old_installments
+    apartment_document, sales_ui_salesperson_api_client, has_old_installments
 ):
     project_uuid = apartment_document.project_uuid
     data = [
@@ -234,7 +234,7 @@ def test_set_project_installments(
         ProjectInstallmentTemplate.objects.count() == 3 if has_old_installments else 1
     )
 
-    response = drupal_salesperson_api_client.post(
+    response = sales_ui_salesperson_api_client.post(
         reverse(
             "apartment:project-installment-template-list",
             kwargs={"project_uuid": project_uuid},
@@ -275,7 +275,7 @@ def test_set_project_installments(
 
 @pytest.mark.django_db
 def test_set_project_installments_percentage_specifier_required_for_percentages(
-    apartment_document, drupal_salesperson_api_client
+    apartment_document, sales_ui_salesperson_api_client
 ):
     project_uuid = apartment_document.project_uuid
     data = [
@@ -287,7 +287,7 @@ def test_set_project_installments_percentage_specifier_required_for_percentages(
         }
     ]
 
-    response = drupal_salesperson_api_client.post(
+    response = sales_ui_salesperson_api_client.post(
         reverse(
             "apartment:project-installment-template-list",
             kwargs={"project_uuid": project_uuid},
@@ -335,12 +335,12 @@ def test_set_project_installments_percentage_specifier_required_for_percentages(
     ],
 )
 def test_set_project_installments_errors(
-    apartment_document, drupal_salesperson_api_client, input, expected_error
+    apartment_document, sales_ui_salesperson_api_client, input, expected_error
 ):
     project_uuid = apartment_document.project_uuid
     data = [input]
 
-    response = drupal_salesperson_api_client.post(
+    response = sales_ui_salesperson_api_client.post(
         reverse(
             "apartment:project-installment-template-list",
             kwargs={"project_uuid": project_uuid},
@@ -389,7 +389,7 @@ def test_apartment_installments_endpoint_unauthorized(
 
 @pytest.mark.django_db
 def test_apartment_installments_endpoint_data(
-    apartment_document, drupal_salesperson_api_client
+    apartment_document, sales_ui_salesperson_api_client
 ):
     reservation = ApartmentReservationFactory()
     ApartmentInstallmentFactory(
@@ -417,7 +417,7 @@ def test_apartment_installments_endpoint_data(
         "application_form:apartment-installment-list",
         kwargs={"apartment_reservation_id": reservation.id},
     )
-    response = drupal_salesperson_api_client.get(url, format="json")
+    response = sales_ui_salesperson_api_client.get(url, format="json")
 
     assert response.status_code == 200
     assert response.data == [
@@ -443,7 +443,7 @@ def test_apartment_installments_endpoint_data(
 @pytest.mark.parametrize("has_old_installments", (False, True))
 @pytest.mark.django_db
 def test_set_apartment_installments(
-    drupal_salesperson_api_client, has_old_installments
+    sales_ui_salesperson_api_client, has_old_installments
 ):
     reservation = ApartmentReservationFactory()
 
@@ -474,7 +474,7 @@ def test_set_apartment_installments(
 
     assert ApartmentInstallment.objects.count() == 3 if has_old_installments else 1
 
-    response = drupal_salesperson_api_client.post(
+    response = sales_ui_salesperson_api_client.post(
         reverse(
             "application_form:apartment-installment-list",
             kwargs={"apartment_reservation_id": reservation.id},
@@ -515,7 +515,7 @@ def test_set_apartment_installments(
 @pytest.mark.parametrize("reference_number_given", (False, True))
 @pytest.mark.django_db
 def test_apartment_installment_reference_number_populating(
-    drupal_salesperson_api_client, reference_number_given
+    sales_ui_salesperson_api_client, reference_number_given
 ):
     reservation = ApartmentReservationFactory()
 
@@ -531,7 +531,7 @@ def test_apartment_installment_reference_number_populating(
     if reference_number_given:
         data[0]["reference_number"] = "THIS-SHOULD-BE-IGNORED"
 
-    response = drupal_salesperson_api_client.post(
+    response = sales_ui_salesperson_api_client.post(
         reverse(
             "application_form:apartment-installment-list",
             kwargs={"apartment_reservation_id": reservation.id},
@@ -550,7 +550,7 @@ def test_apartment_installment_reference_number_populating(
 @pytest.mark.parametrize("reference_number_given", (False, True))
 @pytest.mark.django_db
 def test_apartment_installment_reference_number_populating_on_update(
-    drupal_salesperson_api_client, reference_number_given
+    sales_ui_salesperson_api_client, reference_number_given
 ):
     original_reference_number = "ORIGINAL-REFERENCE-NUMBER"
     reservation = ApartmentReservationFactory()
@@ -572,7 +572,7 @@ def test_apartment_installment_reference_number_populating_on_update(
     if reference_number_given:
         data[0]["reference_number"] = "THIS-SHOULD-BE-IGNORED"
 
-    response = drupal_salesperson_api_client.post(
+    response = sales_ui_salesperson_api_client.post(
         reverse(
             "application_form:apartment-installment-list",
             kwargs={"apartment_reservation_id": reservation.id},
@@ -601,7 +601,7 @@ def test_apartment_installment_reference_number_populating_on_update(
     if reference_number_given:
         data[0]["reference_number"] = "THIS-SHOULD-BE-IGNORED"
 
-    response = drupal_salesperson_api_client.post(
+    response = sales_ui_salesperson_api_client.post(
         reverse(
             "application_form:apartment-installment-list",
             kwargs={"apartment_reservation_id": reservation.id},
@@ -630,7 +630,7 @@ def test_apartment_installment_reference_number_populating_on_update(
     if reference_number_given:
         data[0]["reference_number"] = "THIS-SHOULD-BE-IGNORED"
 
-    response = drupal_salesperson_api_client.post(
+    response = sales_ui_salesperson_api_client.post(
         reverse(
             "application_form:apartment-installment-list",
             kwargs={"apartment_reservation_id": reservation.id},
@@ -664,9 +664,9 @@ def test_apartment_installment_invoice_pdf_unauthorized(
 
 @pytest.mark.django_db
 def test_apartment_installment_invoice_pdf(
-    drupal_salesperson_api_client, reservation_with_installments
+    sales_ui_salesperson_api_client, reservation_with_installments
 ):
-    response = drupal_salesperson_api_client.get(
+    response = sales_ui_salesperson_api_client.get(
         reverse(
             "application_form:apartment-installment-invoice",
             kwargs={"apartment_reservation_id": reservation_with_installments.id},
@@ -686,14 +686,14 @@ def test_apartment_installment_invoice_pdf(
 
 @pytest.mark.django_db
 def test_apartment_installment_invoice_pdf_filtering(
-    drupal_salesperson_api_client, reservation_with_installments
+    sales_ui_salesperson_api_client, reservation_with_installments
 ):
     base_url = reverse(
         "application_form:apartment-installment-invoice",
         kwargs={"apartment_reservation_id": reservation_with_installments.id},
     )
 
-    response = drupal_salesperson_api_client.get(
+    response = sales_ui_salesperson_api_client.get(
         base_url + "?types=PAYMENT_1",
         format="json",
     )
@@ -702,7 +702,7 @@ def test_apartment_installment_invoice_pdf_filtering(
     assert response.content
     one_installment_invoice = response.content
 
-    response = drupal_salesperson_api_client.get(
+    response = sales_ui_salesperson_api_client.get(
         base_url + "?types=PAYMENT_1,REFUND",
         format="json",
     )
@@ -717,14 +717,14 @@ def test_apartment_installment_invoice_pdf_filtering(
 @pytest.mark.parametrize("types_param", ("PAYMENT_5", "xxx"))
 @pytest.mark.django_db
 def test_apartment_installment_invoice_pdf_filtering_errors(
-    drupal_salesperson_api_client, reservation_with_installments, types_param
+    sales_ui_salesperson_api_client, reservation_with_installments, types_param
 ):
     base_url = reverse(
         "application_form:apartment-installment-invoice",
         kwargs={"apartment_reservation_id": reservation_with_installments.id},
     )
 
-    response = drupal_salesperson_api_client.get(
+    response = sales_ui_salesperson_api_client.get(
         base_url + "?types={types_param}",
         format="json",
     )
@@ -750,14 +750,14 @@ def test_add_installments_to_be_sent_to_sap_at_unauthorized(
 
 @pytest.mark.django_db
 def test_add_installments_to_be_sent_to_sap_at(
-    drupal_salesperson_api_client, reservation_with_installments
+    sales_ui_salesperson_api_client, reservation_with_installments
 ):
     base_url = reverse(
         "application_form:apartment-installment-add-to-be-sent-to-sap",
         kwargs={"apartment_reservation_id": reservation_with_installments.id},
     )
 
-    response = drupal_salesperson_api_client.post(
+    response = sales_ui_salesperson_api_client.post(
         base_url + "?types=PAYMENT_1",
         format="json",
     )
@@ -786,20 +786,20 @@ def test_add_installments_to_be_sent_to_sap_at(
 
 @pytest.mark.django_db
 def test_add_installments_to_be_sent_to_sap_at_already_added(
-    drupal_salesperson_api_client, reservation_with_installments
+    sales_ui_salesperson_api_client, reservation_with_installments
 ):
     base_url = reverse(
         "application_form:apartment-installment-add-to-be-sent-to-sap",
         kwargs={"apartment_reservation_id": reservation_with_installments.id},
     )
 
-    response = drupal_salesperson_api_client.post(
+    response = sales_ui_salesperson_api_client.post(
         base_url + "?types=PAYMENT_1",
         format="json",
     )
     assert response.status_code == 200
 
-    response = drupal_salesperson_api_client.post(
+    response = sales_ui_salesperson_api_client.post(
         base_url + "?types=PAYMENT_1",
         format="json",
     )


### PR DESCRIPTION
Fixed reservation transferring, which was broken because of a minor bug in reservation metadata handler field populating that managed to slip through when [that same thing was fixed for other parts of the system a while ago](https://github.com/City-of-Helsinki/apartment-application-service/pull/261).

This PR also includes a somewhat related fix to tests, which makes them test salesperson users better (this would have caught the bug).