### PR TITLE
Fix translations by fixing the compilemessages command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,6 @@ FROM appbase as staticbuilder
 ENV VAR_ROOT /app
 COPY --chown=1001:1001 . /app
 RUN SECRET_KEY="only-used-for-collectstatic" python manage.py collectstatic --noinput
-RUN SECRET_KEY="only-used-for-compilemessages" python manage.py compilemessages
 
 # ==============================
 FROM appbase as development
@@ -39,6 +38,9 @@ ENV DEV_SERVER=1
 
 COPY --chown=1001:1001 . /app/
 
+# required to make compilemessages command work in OpenShift
+RUN chmod -R g+w /app/locale && chgrp -R root /app/locale
+
 USER 1001
 
 EXPOSE 8081/tcp
@@ -49,6 +51,9 @@ FROM appbase as production
 
 COPY --from=staticbuilder --chown=1001:1001 /app/static /app/static
 COPY --chown=1001:1001 . /app/
+
+# required to make compilemessages command work in OpenShift
+RUN chmod -R g+w /app/locale && chgrp -R root /app/locale
 
 USER 1001
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -38,6 +38,10 @@ if [[ "$CREATE_DATA_TRANSFER_PATH" = "1" ]]; then
     echo "Apartment data transfer folder created"
 fi
 
+# Compile messages to make translations work
+echo "Compile messages to make translations work"
+./manage.py compilemessages
+
 # Start server
 if [[ ! -z "$@" ]]; then
     "$@"


### PR DESCRIPTION
Django `compilemessages` command needs to be run in the entry point script in order to get it working with the current Docker Compose config. That in turn won't work in OpenShift unless `/locale` directory is writeable by `root` group, so that needed to be changed also.

Related to [ASU-1559](https://helsinkisolutionoffice.atlassian.net/browse/ASU-1559)