### PR TITLE
ASU-1563 | Fix customer missing has_children information

### DIFF
--- a/application_form/services/application.py
+++ b/application_form/services/application.py
@@ -90,7 +90,9 @@ def create_application(
     data = application_data.copy()
     profile = data.pop("profile")
     additional_applicant_data = data.pop("additional_applicant")
-    customer = get_or_create_customer_from_profiles(profile, additional_applicant_data)
+    customer = get_or_create_customer_from_profiles(
+        profile, additional_applicant_data, data.get("has_children")
+    )
     application = Application.objects.create(
         external_uuid=data.pop("external_uuid"),
         applicants_count=2 if additional_applicant_data else 1,

--- a/application_form/services/export.py
+++ b/application_form/services/export.py
@@ -37,7 +37,7 @@ def _get_reservation_cell_value(column_name, apartment, reservation=None):
         else:
             return operator.attrgetter(column_name)(reservation.customer)
     if column_name == "has_children":
-        return bool(reservation.customer.has_children)
+        return bool(reservation.has_children)
     if column_name == "lottery_position":
         return reservation.application_apartment.lotteryeventresult.result_position
     if column_name == "right_of_residence":

--- a/customer/services.py
+++ b/customer/services.py
@@ -23,11 +23,14 @@ class SecondaryProfileData(TypedDict):
 def get_or_create_customer_from_profiles(
     primary_profile: Profile,
     secondary_profile_data: SecondaryProfileData = None,
+    has_children: bool = None,
 ) -> Customer:
     if not secondary_profile_data:
         # this is a single person Customer
         customer = Customer.objects.get_or_create(
-            primary_profile=primary_profile, secondary_profile=None
+            primary_profile=primary_profile,
+            secondary_profile=None,
+            has_children=has_children,
         )[0]
         return customer
 
@@ -66,5 +69,6 @@ def get_or_create_customer_from_profiles(
     customer = Customer.objects.create(
         primary_profile=primary_profile,
         secondary_profile=secondary_profile,
+        has_children=has_children,
     )
     return customer


### PR DESCRIPTION
Lottery result CSV report used the `has_children` field from `Customer` who owns the reservation
However, there is a flaw:
- When creating a reservation manually from Sales tool, the `reservation.has_children` is set based on `customer.has_children`
- When creating a normal application from Drupal, the `application.has_children` is ignored when creating new Customer, as a result, customers are most likely missing `has_children` value

To fix the problem:
- In the CSV, use the `reservation.has_children` instead of `customer.has_children` because it's more reliable
- Update the `create_application` logic to include `application.has_children` value when creating new customer