### PR TITLE
ASU-1600 | Changes to support reservation list fetching by apartment

### DIFF
--- a/apartment/api/sales/serializers.py
+++ b/apartment/api/sales/serializers.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+from uuid import UUID
 
 from apartment.utils import get_apartment_state
 from application_form.api.sales.serializers import SalesApartmentReservationSerializer
@@ -9,27 +10,39 @@ class ApartmentSerializer(serializers.Serializer):
     apartment_number = serializers.CharField()
     apartment_structure = serializers.CharField()
     living_area = serializers.FloatField()
-    reservations = serializers.SerializerMethodField()
     url = serializers.CharField()
     state = serializers.SerializerMethodField()
-
-    def get_reservations(self, obj):
-        reservations = []
-        if self.context.get("reservations"):
-            reservations = sorted(
-                [
-                    r
-                    for r in self.context.get("reservations")
-                    if str(r.apartment_uuid) == obj.uuid
-                ],
-                key=lambda x: x.list_position,
-            )
-
-        return SalesApartmentReservationSerializer(
-            reservations,
-            many=True,
-            context={"project_uuid": self.context["project_uuid"]},
-        ).data
+    reservation_count = serializers.SerializerMethodField()
+    winning_reservation = serializers.SerializerMethodField()
 
     def get_state(self, obj):
         return get_apartment_state(obj.uuid)
+
+    def get_reservation_count(self, obj):
+        return next(
+            (
+                apartment["reservation_count"]
+                for apartment in self.context["reservation_counts"]
+                if apartment["apartment_uuid"] == UUID(obj.uuid)
+            ),
+            0,
+        )
+
+    def get_winning_reservation(self, obj):
+        winning_reservation = next(
+            (
+                reservation
+                for reservation in self.context["winning_reservations"]
+                if reservation.apartment_uuid == UUID(obj.uuid)
+            ),
+            None,
+        )
+
+        return (
+            SalesApartmentReservationSerializer(
+                winning_reservation,
+                context={"project_uuid": self.context["project_uuid"]},
+            ).data
+            if winning_reservation
+            else None
+        )

--- a/apartment/api/sales/serializers.py
+++ b/apartment/api/sales/serializers.py
@@ -2,7 +2,9 @@ from rest_framework import serializers
 from uuid import UUID
 
 from apartment.utils import get_apartment_state
-from application_form.api.sales.serializers import SalesApartmentReservationSerializer
+from application_form.api.sales.serializers import (
+    SalesWinningApartmentReservationSerializer,
+)
 
 
 class ApartmentSerializer(serializers.Serializer):
@@ -39,7 +41,7 @@ class ApartmentSerializer(serializers.Serializer):
         )
 
         return (
-            SalesApartmentReservationSerializer(
+            SalesWinningApartmentReservationSerializer(
                 winning_reservation,
                 context={"project_uuid": self.context["project_uuid"]},
             ).data

--- a/apartment/api/views.py
+++ b/apartment/api/views.py
@@ -20,7 +20,10 @@ from apartment.elastic.queries import (
     get_projects,
 )
 from apartment.models import ProjectExtraData
-from application_form.api.sales.serializers import ProjectExtraDataSerializer
+from application_form.api.sales.serializers import (
+    ProjectExtraDataSerializer,
+    SalesApartmentReservationSerializer,
+)
 from application_form.enums import ApartmentReservationState
 from application_form.models import (
     ApartmentReservation,
@@ -41,6 +44,19 @@ class ApartmentAPIView(APIView):
         project_uuid = request.GET.get("project_uuid", None)
         apartments = get_apartments(project_uuid)
         serializer = ApartmentDocumentSerializer(apartments, many=True)
+        return Response(serializer.data)
+
+
+class ApartmentReservationsAPIView(APIView):
+    http_method_names = ["get"]
+
+    def get(self, request, apartment_uuid):
+        serializer = SalesApartmentReservationSerializer(
+            ApartmentReservation.objects.related_fields()
+            .filter(apartment_uuid=apartment_uuid)
+            .order_by("list_position"),
+            many=True,
+        )
         return Response(serializer.data)
 
 

--- a/apartment/urls.py
+++ b/apartment/urls.py
@@ -3,6 +3,7 @@ from rest_framework.routers import DefaultRouter
 
 from apartment.api.views import (
     ApartmentAPIView,
+    ApartmentReservationsAPIView,
     ProjectAPIView,
     ProjectExportApplicantsAPIView,
     ProjectExportLotteryResultsAPIView,
@@ -15,6 +16,11 @@ router = DefaultRouter()
 
 urlpatterns = [
     path("sales/apartments/", ApartmentAPIView.as_view(), name="apartment-list"),
+    path(
+        "sales/apartments/<uuid:apartment_uuid>/reservations/",
+        ApartmentReservationsAPIView.as_view(),
+        name="apartment-detail-reservations-list",
+    ),
     path("sales/report/", SaleReportAPIView.as_view(), name="sale-report"),
     path(
         "sales/projects/",

--- a/application_form/api/sales/serializers.py
+++ b/application_form/api/sales/serializers.py
@@ -99,16 +99,12 @@ class CustomerCompactSerializer(serializers.ModelSerializer):
 
 class SalesApartmentReservationSerializer(ApartmentReservationSerializerBase):
     customer = CustomerCompactSerializer()
-    has_multiple_winning_apartments = serializers.BooleanField(
-        source="customer_has_other_winning_apartments"
-    )
     cancellation_reason = serializers.SerializerMethodField()
     cancellation_timestamp = serializers.SerializerMethodField()
 
     class Meta(ApartmentReservationSerializerBase.Meta):
         fields = ApartmentReservationSerializerBase.Meta.fields + (
             "customer",
-            "has_multiple_winning_apartments",
             "cancellation_reason",
             "cancellation_timestamp",
         )
@@ -142,6 +138,17 @@ class SalesApartmentReservationSerializer(ApartmentReservationSerializerBase):
             except ObjectDoesNotExist:
                 return None
         return None
+
+
+class SalesWinningApartmentReservationSerializer(SalesApartmentReservationSerializer):
+    has_multiple_winning_apartments = serializers.BooleanField(
+        source="customer_has_other_winning_apartments"
+    )
+
+    class Meta(SalesApartmentReservationSerializer.Meta):
+        fields = SalesApartmentReservationSerializer.Meta.fields + (
+            "has_multiple_winning_apartments",
+        )
 
 
 class RootApartmentReservationSerializer(ApartmentReservationSerializerBase):


### PR DESCRIPTION
Implemented a couple of changes to support how reservations are fetched in the Sales UI's project detail view, because the old way of fetching them all right from the start was not feasible for production's thousands of reservations. 

* Replaced `reservations` field with `winning_reservation` and `reservation_count` fields in project detail view apartment data

* Added new API endpoint `/v1/sales/apartments/<apartment UUID>/reservations/` which returns the given apartment's all reservations sorted by list_position

