### PR TITLE
ASU-1601 | Fix update customer data from application data

### DIFF
--- a/customer/services.py
+++ b/customer/services.py
@@ -30,8 +30,9 @@ def get_or_create_customer_from_profiles(
         customer = Customer.objects.get_or_create(
             primary_profile=primary_profile,
             secondary_profile=None,
-            has_children=has_children,
         )[0]
+        customer.has_children = has_children
+        customer.save()
         return customer
 
     secondary_profile_ssn = (
@@ -46,6 +47,8 @@ def get_or_create_customer_from_profiles(
             primary_profile=primary_profile,
             secondary_profile__national_identification_number=secondary_profile_ssn,
         )
+        customer.has_children = has_children
+        customer.save()
         return customer
     except Customer.DoesNotExist:
         pass


### PR DESCRIPTION
There was a logical error when creating an application for an existed customer.
If the application.has_children is different from the current customer.has_children, Django misunderstood that this is a new customer and try to create duplicated user info.
Fixed so that Django only identifies a customer by profiles (disregarding the `customer.has_children` info). Then overwrite customer has_children info using the `application.has_children` after getting/creating the customer object