### PR TITLE
ASU-1604 | Project detail endpoint performance improvements

### DIFF
--- a/apartment/api/sales/serializers.py
+++ b/apartment/api/sales/serializers.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 from uuid import UUID
 
-from apartment.utils import get_apartment_state
+from apartment.utils import get_apartment_state_from_reserved_reservations
 from application_form.api.sales.serializers import (
     SalesWinningApartmentReservationSerializer,
 )
@@ -18,7 +18,12 @@ class ApartmentSerializer(serializers.Serializer):
     winning_reservation = serializers.SerializerMethodField()
 
     def get_state(self, obj):
-        return get_apartment_state(obj.uuid)
+        reserved_reservations = [
+            reservation
+            for reservation in self.context["reserved_reservations"]
+            if reservation.apartment_uuid == UUID(obj.uuid)
+        ]
+        return get_apartment_state_from_reserved_reservations(reserved_reservations)
 
     def get_reservation_count(self, obj):
         return next(

--- a/apartment/api/serializers.py
+++ b/apartment/api/serializers.py
@@ -184,6 +184,7 @@ class ProjectDocumentDetailSerializer(ProjectDocumentSerializerBase):
         )
         winning_reservations = (
             ApartmentReservation.objects.filter(apartment_uuid__in=self.apartment_uuids)
+            .related_fields()
             .active()
             .filter(queue_position=1)
             .annotate(
@@ -204,6 +205,9 @@ class ProjectDocumentDetailSerializer(ProjectDocumentSerializerBase):
                 "project_uuid": obj.project_uuid,
                 "reservation_counts": reservation_counts,
                 "winning_reservations": winning_reservations,
+                "reserved_reservations": ApartmentReservation.objects.filter(
+                    apartment_uuid__in=self.apartment_uuids
+                ).reserved(),
             },
         ).data
 
@@ -225,6 +229,9 @@ class ProjectDocumentDetailSerializer(ProjectDocumentSerializerBase):
             Application.objects.filter(
                 application_apartments__apartment_uuid__in=self.apartment_uuids
             )
+            # this is needed so that decryption won't be used, which would slow this
+            # query down substantially
+            .only("id")
             .distinct()
             .count()
         )

--- a/apartment/utils.py
+++ b/apartment/utils.py
@@ -2,7 +2,7 @@ from apartment.enums import ApartmentState
 from application_form.models import ApartmentReservation
 
 
-def get_apartment_state(apartment_uuid):
+def get_apartment_state_from_apartment_uuid(apartment_uuid):
     try:
         reserved_reservation = ApartmentReservation.objects.reserved().get(
             apartment_uuid=apartment_uuid
@@ -14,4 +14,16 @@ def get_apartment_state(apartment_uuid):
 
     return ApartmentState.get_from_reserved_reservation_state(
         reserved_reservation.state
+    ).value
+
+
+def get_apartment_state_from_reserved_reservations(reserved_reservations):
+    reservation_list = list(reserved_reservations)
+    if len(reservation_list) == 0:
+        return ApartmentState.FREE.value
+    elif len(reservation_list) > 1:
+        return ApartmentState.REVIEW.value
+
+    return ApartmentState.get_from_reserved_reservation_state(
+        reservation_list[0].state
     ).value

--- a/application_form/api/serializers.py
+++ b/application_form/api/serializers.py
@@ -22,7 +22,6 @@ from application_form.models import (
     ApartmentReservationStateChangeEvent,
     Applicant,
     Application,
-    LotteryEvent,
     Offer,
 )
 from application_form.services.application import create_application
@@ -204,7 +203,6 @@ class ReservationOfferSerializer(
 
 class ApartmentReservationSerializerBase(serializers.ModelSerializer):
     state = EnumField(ApartmentReservationState, read_only=True)
-    queue_position = serializers.SerializerMethodField()
     lottery_position = IntegerField(
         source="application_apartment.lotteryeventresult.result_position",
         allow_null=True,
@@ -243,12 +241,6 @@ class ApartmentReservationSerializerBase(serializers.ModelSerializer):
             "is_age_over_55",
             "is_right_of_occupancy_housing_changer",
         )
-
-    def get_queue_position(self, obj):
-        if LotteryEvent.objects.filter(apartment_uuid=obj.apartment_uuid).exists():
-            return obj.queue_position
-        else:
-            return None
 
 
 class ApartmentReservationSerializer(ApartmentReservationSerializerBase):

--- a/application_form/models/reservation.py
+++ b/application_form/models/reservation.py
@@ -41,6 +41,7 @@ class ApartmentReservationQuerySet(models.QuerySet):
             .select_related("customer__primary_profile")
             .select_related("customer__secondary_profile")
             .select_related("application_apartment")
+            .select_related("application_apartment__lotteryeventresult")
         )
 
     def active(self):

--- a/application_form/services/export.py
+++ b/application_form/services/export.py
@@ -10,7 +10,7 @@ from apartment.elastic.queries import (
     get_project,
 )
 from apartment.enums import ApartmentState
-from apartment.utils import get_apartment_state
+from apartment.utils import get_apartment_state_from_apartment_uuid
 from application_form.models import ApartmentReservation
 from application_form.utils import get_apartment_number_sort_tuple
 
@@ -228,7 +228,8 @@ class SaleReportExportService(CSVExportService):
             [
                 apartment_uuid
                 for apartment_uuid in apartment_uuids
-                if get_apartment_state(apartment_uuid) == ApartmentState.SOLD.value
+                if get_apartment_state_from_apartment_uuid(apartment_uuid)
+                == ApartmentState.SOLD.value
             ]
         )
         reported_sold = len(

--- a/application_form/tests/api/test_project_reservation_view.py
+++ b/application_form/tests/api/test_project_reservation_view.py
@@ -77,7 +77,7 @@ def test_list_project_reservations_get_without_lottery_data(
     assert len(response.data) == apartment_reservation_count
     for item in response.data:
         assert item["lottery_position"] is None
-        assert item["queue_position"] is None
+        assert item["queue_position"] is not None
 
 
 @pytest.mark.django_db

--- a/customer/tests/api/sales/test_customer_api.py
+++ b/customer/tests/api/sales/test_customer_api.py
@@ -52,6 +52,7 @@ def test_get_customer_api_detail(sales_ui_salesperson_api_client):
         apartment_uuid=apartment.uuid,
         has_hitas_ownership=True,
         has_children=False,
+        queue_position=1,
     )
     installment = ApartmentInstallmentFactory(
         apartment_reservation=reservation, value=100
@@ -115,7 +116,7 @@ def test_get_customer_api_detail(sales_ui_salesperson_api_client):
             ],
             "lottery_position": None,
             "project_lottery_completed": False,
-            "queue_position": None,
+            "queue_position": 1,
             "priority_number": reservation.application_apartment.priority_number,
             "state": reservation.state.value,
             "offer": None,


### PR DESCRIPTION
Some performance improvements to project detail API endpoint:

* tweaked application_count to not use decryption which it doesn't even need. That was very slow before.
* removed the feature that queue_position was null when lottery wasn't executed. This was causing a lot of queries, and it wasn't even needed for anything anymore
* added a bunch of prefetching to the db queries