### PR TITLE
Check requirements files in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -141,6 +141,11 @@ jobs:
           flake8
           isort . --check-only --diff
 
+      - name: Check requirements files
+        if: ${{ matrix.python == '3.8' }}
+        run: |
+          ./check-requirements-files
+
       - name: Run tests
         run: |
           pytest -ra -vvv --doctest-modules --cov=.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-check: lint check-django check-migrations test
+check: lint check-django check-migrations check-requirements test
 
 fix: fix-imports fix-code-style
 
@@ -25,6 +25,9 @@ check-django:
 
 check-migrations:
 	./manage.py makemigrations --check --dry-run
+
+check-requirements:
+	./check-requirements-files
 
 test:
 	pytest

--- a/check-requirements-files
+++ b/check-requirements-files
@@ -1,0 +1,35 @@
+#!/bin/sh
+# Check that requirements*.txt files are compiled correctly from *.in files
+
+files=*.in
+
+if [ -n "$1" ]; then
+    files=$*
+fi
+
+failed=""
+
+for file in $files; do
+    bn=$(basename $(basename "$file" .in) .txt)
+    infile=$bn.in
+    reqtxt=$bn.txt
+    copy=$bn-COMPILED.txt
+
+    echo -n "Checking that $reqtxt is compiled from $infile..."
+
+    cp -f "$reqtxt" "$copy"
+    pip-compile --resolver=backtracking --quiet --output-file="$copy" "$infile"
+    sed -i "s/--output-file=$copy //" "$copy"
+    echo
+    if ! diff -u "$reqtxt" "$copy"; then
+        failed="$failed $reqtxt"
+    fi
+    rm -f "$copy"
+done
+
+if [ -n "$failed" ]; then
+    echo "Not correctly compiled:$failed"
+    exit 1
+else
+    echo "All checked requirements files were correctly compiled."
+fi


### PR DESCRIPTION
Make sure that the requirements*.txt files are correctly compiled from their *.in counterparts.

Add a script that checks the requirements files and hook it to CI in GitHub actions and add it also to the Makefile.

This should make it safer to merge updates to requirements.txt, since now we can be sure that the version change doesn't cause any conflicts between the package versions.