### PR TITLE
Fix couple ElasticSearch searches without index

### DIFF
--- a/application_form/tests/utils.py
+++ b/application_form/tests/utils.py
@@ -4,6 +4,7 @@ import uuid
 from datetime import date
 from typing import List, Tuple
 
+from django.db.models.fields import settings
 from elasticsearch_dsl import Search
 
 from connections.enums import ApartmentStateOfSale
@@ -14,7 +15,7 @@ _logger = logging.getLogger(__name__)
 
 def get_elastic_apartments_uuids() -> Tuple[uuid.UUID, List[uuid.UUID]]:
     s_obj = (
-        Search()
+        Search(index=settings.APARTMENT_INDEX_NAME)
         .filter("term", _language__keyword="fi")
         .filter("term", apartment_state_of_sale__keyword=ApartmentStateOfSale.FOR_SALE)
     )

--- a/connections/tests/utils.py
+++ b/connections/tests/utils.py
@@ -162,7 +162,7 @@ def publish_elastic_apartments(
     get_connection().indices.refresh(index=settings.APARTMENT_INDEX_NAME)
 
     s_obj = (
-        Search()
+        Search(index=settings.APARTMENT_INDEX_NAME)
         .filter("term", _language__keyword="fi")
         .filter("term", apartment_state_of_sale__keyword=ApartmentStateOfSale.FOR_SALE)
     )


### PR DESCRIPTION
These searches were doing the search to **all** indices, which is problematic if there are several indices in the used ES instance.

This was causing tests to fail for me locally, since I had one ES index which had an apartment A0 without project_uuid and the code fails if there is no project_uuid.