### PR TITLE
Enable django_extensions on DEBUG mode

### DIFF
--- a/apartment_application_service/settings.py
+++ b/apartment_application_service/settings.py
@@ -7,6 +7,8 @@ import sentry_sdk
 from django.utils.translation import gettext_lazy as _
 from sentry_sdk.integrations.django import DjangoIntegration
 
+from .utils import is_module_available
+
 checkout_dir = environ.Path(__file__) - 2
 assert os.path.exists(checkout_dir("manage.py"))
 
@@ -181,6 +183,10 @@ INSTALLED_APPS = [
     "utils",
     "cost_index",
 ]
+
+if DEBUG and is_module_available("django_extensions"):
+    INSTALLED_APPS += ["django_extensions"]
+
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",

--- a/apartment_application_service/utils.py
+++ b/apartment_application_service/utils.py
@@ -1,3 +1,6 @@
+import importlib
+
+
 class SafeAttributeObject:
     def __init__(self, obj):
         self.obj = obj
@@ -14,3 +17,11 @@ def update_obj(obj, data):
         setattr(obj, field, value)
     obj.save()
     return obj
+
+
+def is_module_available(module_name):
+    try:
+        importlib.import_module(module_name)
+    except ImportError:
+        return False
+    return True

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,5 +1,6 @@
 -c requirements.txt
 black==22.3.0
+django-extensions
 django-test-migrations
 factory-boy
 flake8

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,12 +4,20 @@
 #
 #    pip-compile --strip-extras requirements-dev.in
 #
+asgiref==3.7.2
+    # via
+    #   -c requirements.txt
+    #   django
 astroid==2.15.8
     # via pylint
 asttokens==2.4.0
     # via stack-data
 backcall==0.2.0
     # via ipython
+backports-zoneinfo==0.2.1
+    # via
+    #   -c requirements.txt
+    #   django
 black==22.3.0
     # via -r requirements-dev.in
 build==1.0.3
@@ -28,6 +36,12 @@ dill==0.3.7
     # via pylint
 distlib==0.3.7
     # via virtualenv
+django==4.2.6
+    # via
+    #   -c requirements.txt
+    #   django-extensions
+django-extensions==3.2.3
+    # via -r requirements-dev.in
 django-test-migrations==1.3.0
     # via -r requirements-dev.in
 exceptiongroup==1.1.3
@@ -149,6 +163,10 @@ six==1.16.0
     #   -c requirements.txt
     #   asttokens
     #   python-dateutil
+sqlparse==0.4.4
+    # via
+    #   -c requirements.txt
+    #   django
 stack-data==0.6.3
     # via ipython
 termcolor==2.3.0
@@ -175,6 +193,7 @@ traitlets==5.11.2
 typing-extensions==4.8.0
     # via
     #   -c requirements.txt
+    #   asgiref
     #   astroid
     #   black
     #   django-test-migrations


### PR DESCRIPTION
Add django-extensions to requirements-dev and add it to INSTALLED_APPS when DEBUG is enabled and the module is installed.

Most importantly (for me at least) this allows using the very useful `manage.py shell_plus` command on the local development environment.