### PR TITLE
CI: Add check-requirements job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,6 +79,18 @@ env:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
+  check-requirements:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
+          cache: 'pip'
+          cache-dependency-path: requirements-dev.txt
+      - run: pip install -r requirements-dev.txt
+      - run: ./check-requirements-files
+
   build:
     runs-on: ubuntu-latest
     strategy:
@@ -142,12 +154,6 @@ jobs:
           black --check .
           flake8
           isort . --check-only --diff
-
-      # TODO temporarily disabled
-      # - name: Check requirements files
-      #   if: ${{ matrix.python == '3.8' }}
-      #   run: |
-      #     ./check-requirements-files
 
       - name: Run tests
         run: |

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,5 +1,6 @@
 -c requirements.txt
 black==22.3.0
+coverage
 django-extensions
 django-test-migrations
 factory-boy

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -29,7 +29,9 @@ click==8.1.7
     #   black
     #   pip-tools
 coverage==7.3.2
-    # via pytest-cov
+    # via
+    #   -r requirements-dev.in
+    #   pytest-cov
 decorator==5.1.1
     # via ipython
 dill==0.3.7


### PR DESCRIPTION
Add back the check for requirements files, but this time as a separate job so that its result can be ignored if it starts to yield problems again.