### PR TITLE
users: Add NIN to profile API (ASU-1703)

### DIFF
--- a/users/api/serializers.py
+++ b/users/api/serializers.py
@@ -44,6 +44,7 @@ class ProfileSerializer(ProfileSerializerBase):
         fields = ProfileSerializerBase.Meta.fields + (
             "street_address",
             "date_of_birth",
+            "national_identification_number",
             "city",
             "postal_code",
             "contact_language",

--- a/users/tests/conftest.py
+++ b/users/tests/conftest.py
@@ -23,6 +23,11 @@ PROFILE_TEST_DATA = {
     "contact_language": "fi",
 }
 
+PROFILE_TEST_DATA_WITH_NIN = {
+    **PROFILE_TEST_DATA,
+    "national_identification_number": "250180-8887",
+}
+
 OTHER_PROFILE_TEST_DATA = {
     **PROFILE_TEST_DATA,
     "id": "872e8f85-e23a-42ed-9364-c3620c190d98",
@@ -34,6 +39,11 @@ TEST_USER_PASSWORD = "test password"
 @pytest.fixture
 def profile():
     return _create_profile(PROFILE_TEST_DATA, TEST_USER_PASSWORD)
+
+
+@pytest.fixture
+def profile_with_nin():
+    return _create_profile(PROFILE_TEST_DATA_WITH_NIN, TEST_USER_PASSWORD)
 
 
 @pytest.fixture


### PR DESCRIPTION
Add national_identification_number field to the profile API endpoints.

This allows API users to create Profiles with NIN and get its value with the "get details" request.

Also amend the tests and add couple new test cases.

Note: Currently NIN is not validated.
