### PR TITLE
Fix _shift_positions for cancelled reservations

### DIFF
--- a/application_form/services/queue.py
+++ b/application_form/services/queue.py
@@ -178,7 +178,9 @@ def _shift_positions(
         )
         return
 
-    reservations = ApartmentReservation.objects.filter(apartment_uuid=apartment_uuid)
+    reservations = ApartmentReservation.objects.active().filter(
+        apartment_uuid=apartment_uuid
+    )
     if not deleted and reservations.filter(queue_position=None).exists():
         raise RuntimeError(
             "This function cannot be used for adding a reservation when the apartment "


### PR DESCRIPTION
Currently when adding a new application to an apartment that already has cancelled reservations the _shift_positions fails with the following error:

    RuntimeError: This function cannot be used for adding a
    reservation when the apartment has reservations without a queue_position.

This was caused because cancelled reservations have queue_position == None.

Fix the issue by filtering out the cancelled reservations.