### PR TITLE
Use project_contract_combined_terms in the PDFs

### DIFF
--- a/apartment/elastic/documents.py
+++ b/apartment/elastic/documents.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from elasticsearch_dsl import Boolean, Date, Document, Float, Keyword, Long
+from elasticsearch_dsl import Boolean, Date, Document, Float, Keyword, Long, Text
 
 from cost_index.utils import (
     current_right_of_occupancy_payment,
@@ -151,6 +151,8 @@ class ApartmentDocument(ReadOnlyDocument):
 
     project_contract_apartment_completion_selection_2_start = Date()
     project_contract_apartment_completion_selection_2_end = Date()
+    project_contract_customer_handover = Text()
+    project_contract_bill_of_sale_terms = Text()
     project_contract_other_terms = Keyword()
     project_contract_usage_fees = Keyword()
     project_contract_right_of_occupancy_payment_verification = Keyword()
@@ -173,3 +175,13 @@ class ApartmentDocument(ReadOnlyDocument):
         return reservation_right_of_occupancy_payment(
             reservation_id, self.uuid, self.right_of_occupancy_payment
         )
+
+    @property
+    def project_contract_combined_terms(self):
+        items = [
+            self.project_contract_customer_handover,
+            self.project_contract_bill_of_sale_terms,
+            self.project_contract_other_terms,
+        ]
+        non_empty_items = [x for x in items if isinstance(x, str) and x]
+        return "\n\n".join(non_empty_items)

--- a/apartment/tests/factories.py
+++ b/apartment/tests/factories.py
@@ -183,6 +183,8 @@ class ApartmentDocumentFactory(ElasticFactory):
         start_date=timezone.localdate() + timedelta(days=1),
         end_date=timezone.localdate() + timedelta(days=7),
     )
+    project_contract_customer_handover = fuzzy.FuzzyText()
+    project_contract_bill_of_sale_terms = fuzzy.FuzzyText()
     project_contract_other_terms = fuzzy.FuzzyText()
     project_contract_usage_fees = fuzzy.FuzzyText()
     project_contract_right_of_occupancy_payment_verification = fuzzy.FuzzyText()

--- a/application_form/pdf/haso.py
+++ b/application_form/pdf/haso.py
@@ -218,7 +218,7 @@ def get_haso_contract_pdf_data(
         ),
         signing_place_and_time="Helsinki",  # TODO: Is Signing Time needed?
         project_acc_salesperson=apartment.project_acc_salesperson,
-        project_contract_other_terms=apartment.project_contract_other_terms,
+        project_contract_other_terms=apartment.project_contract_combined_terms,
         project_contract_usage_fees=apartment.project_contract_usage_fees,
         project_contract_right_of_occupancy_payment_verification=(
             apartment.project_contract_right_of_occupancy_payment_verification

--- a/application_form/pdf/hitas.py
+++ b/application_form/pdf/hitas.py
@@ -392,7 +392,7 @@ def create_hitas_contract_pdf(reservation: ApartmentReservation) -> BytesIO:
         )
         if apartment.project_contract_construction_permit_requested
         else None,
-        project_contract_other_terms=apartment.project_contract_other_terms,
+        project_contract_other_terms=apartment.project_contract_combined_terms,
         project_documents_delivered=apartment.project_documents_delivered,
         signing_place_and_time="Helsingin kaupunki",
         signing_text="Kauppakirja oikeaksi todistetaan",


### PR DESCRIPTION
It seems that in ElasticSearch the data in the project_contract_other_terms field is not enough for the PDF, but we need to combine also data from two other fields.  Add the two other fields to ApartmentDocument and a property attribute which combines those fields with couple newlines.

Update the PDF generation code to use the combined field.