### PR TITLE
Improve version getter in settings

### DIFF
--- a/apartment_application_service/settings.py
+++ b/apartment_application_service/settings.py
@@ -1,5 +1,4 @@
 import os
-import subprocess
 from datetime import timedelta
 
 import environ
@@ -8,6 +7,7 @@ from django.utils.translation import gettext_lazy as _
 from sentry_sdk.integrations.django import DjangoIntegration
 
 from .utils import is_module_available
+from .version import get_version
 
 checkout_dir = environ.Path(__file__) - 2
 assert os.path.exists(checkout_dir("manage.py"))
@@ -132,17 +132,12 @@ vars().update(EMAIL_CONFIG)
 if env.str("DEFAULT_FROM_EMAIL"):
     DEFAULT_FROM_EMAIL = env.str("DEFAULT_FROM_EMAIL")
 
-try:
-    version = subprocess.check_output(["git", "rev-parse", "--short", "HEAD"]).strip()
-except Exception:
-    version = "n/a"
-
 SENTRY_DSN = env.str("SENTRY_DSN")
 SENTRY_ENVIRONMENT = env("SENTRY_ENVIRONMENT")
 if SENTRY_DSN and SENTRY_ENVIRONMENT:
     sentry_sdk.init(
         dsn=SENTRY_DSN,
-        release=version,
+        release=get_version(),
         environment=SENTRY_ENVIRONMENT,
         integrations=[DjangoIntegration()],
     )

--- a/apartment_application_service/tests/test_get_version.py
+++ b/apartment_application_service/tests/test_get_version.py
@@ -1,0 +1,91 @@
+import contextlib
+import os
+from unittest.mock import patch
+
+import pytest
+
+from ..version import get_version
+
+TEST_CASES = {
+    "env-tag": (
+        "382b1d3ee9a4ee3c3a5c0c52f03ad2c7b7b5b365",
+        "refs/tags/release-1.0.4",
+        b"382b1d3ee9a4ee3c3a5c0c52f03ad2c7b7b5b365",
+        "release-1.0.4",
+    ),
+    "env-branch": (
+        "382b1d3ee9a4ee3c3a5c0c52f03ad2c7b7b5b365",
+        "refs/heads/main",
+        b"382b1d3ee9a4ee3c3a5c0c52f03ad2c7b7b5b365",
+        "382b1d3",
+    ),
+    "git-commit": (
+        None,
+        None,
+        b"382b1d3\n",
+        "382b1d3",
+    ),
+    "git-commit-spaces": (
+        None,
+        None,
+        b"  382b1d3\n",
+        "382b1d3",
+    ),
+    "env-tag-slash": (
+        "382b1d3ee9a4ee3c3a5c0c52f03ad2c7b7b5b365",
+        "refs/tags/release/1.0.4",
+        b"382b1d3ee9a4ee3c3a5c0c52f03ad2c7b7b5b365",
+        "release_1.0.4",
+    ),
+}
+
+
+@pytest.mark.parametrize("test_case", list(TEST_CASES))
+@patch("apartment_application_service.version.subprocess.check_output")
+def test_get_version(subprocess_check_output, test_case):
+    (commit, ref, git_output, expected_result) = TEST_CASES[test_case]
+    subprocess_check_output.return_value = git_output
+
+    with commit_and_ref_in_env(commit, ref):
+        result = get_version()
+
+    assert result == expected_result
+
+
+@patch("apartment_application_service.version.subprocess.check_output")
+def test_get_version_git_fail(subprocess_check_output):
+    subprocess_check_output.side_effect = Exception("git failed")
+
+    with commit_and_ref_in_env(None, None):
+        result = get_version()
+
+    assert result == "UNKNOWN"
+
+
+@contextlib.contextmanager
+def commit_and_ref_in_env(commit, ref):
+    values = {
+        "OPENSHIFT_BUILD_COMMIT": commit,
+        "OPENSHIFT_BUILD_REFERENCE": ref,
+    }
+    with modified_env(**values):
+        yield
+
+
+@contextlib.contextmanager
+def modified_env(**values):
+    old_values = {name: os.environ.get(name) for name in values.keys()}
+
+    try:
+        _set_env(**values)
+        yield
+    finally:
+        _set_env(**old_values)
+
+
+def _set_env(**values):
+    for name, value in values.items():
+        if value is None:
+            os.environ.pop(name, None)
+        else:
+            os.environ[name] = value

--- a/apartment_application_service/version.py
+++ b/apartment_application_service/version.py
@@ -1,0 +1,34 @@
+import os
+import subprocess
+
+# Environment variable for the commit used for build
+#
+# Value could be e.g. "382b1d3ee9a4ee3c3a5c0c52f03ad2c7b7b5b365"
+commit_var = "OPENSHIFT_BUILD_COMMIT"
+
+# Environment variable for the ref used for build
+#
+# Value could be e.g. "refs/heads/main" or "refs/tags/release-1.0.4".
+ref_var = "OPENSHIFT_BUILD_REFERENCE"
+
+
+def get_version() -> str:
+    commit = os.getenv(commit_var)
+    ref = os.getenv(ref_var)
+
+    if commit and ref:  # Has commit and ref in env vars
+        if ref.startswith("refs/tags/"):
+            return ref.split("refs/tags/", 1)[-1].replace("/", "_")
+        return commit[:7]
+
+    try:
+        return get_version_with_git()
+    except Exception:
+        return "UNKNOWN"
+
+
+def get_version_with_git(rev="HEAD") -> str:
+    git_cmd = ["git", "rev-parse", "--short", rev]
+    git_output = subprocess.check_output(git_cmd)
+    decoded = git_output.decode("utf-8", errors="replace")
+    return decoded.strip()


### PR DESCRIPTION
Move the version getting code to its own module and use that in the settings module.

Read version first from env variables and only fall back to running Git commands.  This avoids the issue on OpenShift containers, where running the Git commands fail with an error.  Those cause false alarms to logs and the "n/a" version isn't even valid for Sentry version string, since they shouldn't contain slashes.