### PR TITLE
Allow disabling applicant duplicate validation

### DIFF
--- a/apartment_application_service/settings.py
+++ b/apartment_application_service/settings.py
@@ -107,6 +107,7 @@ env = environ.Env(
     DRUPAL_SERVER_AUTH_TOKEN=(str, "example-token"),
     DEFAULT_SOLD_APARMENT_TIME_RANGE=(int, 1),
     DEFAULT_APARTMENT_REVALUATION_TIME_RANGE=(int, 1),
+    APPLICANT_DUPLICATE_VALIDATION_DISABLED=(bool, False),
 )
 if os.path.exists(env_file):
     env.read_env(env_file)
@@ -424,6 +425,11 @@ DEFAULT_SOLD_APARMENT_TIME_RANGE = env.int("DEFAULT_SOLD_APARMENT_TIME_RANGE")  
 DEFAULT_APARTMENT_REVALUATION_TIME_RANGE = env.int(
     "DEFAULT_APARTMENT_REVALUATION_TIME_RANGE"
 )  # hours
+
+# Tunables
+APPLICANT_DUPLICATE_VALIDATION_DISABLED = env.bool(
+    "APPLICANT_DUPLICATE_VALIDATION_DISABLED"
+)
 
 # local_settings.py can be used to override environment-specific settings
 # like database and email that differ between development and production.

--- a/application_form/validators.py
+++ b/application_form/validators.py
@@ -2,6 +2,7 @@ from datetime import date
 from typing import List, Tuple, Union
 from uuid import UUID
 
+from django.conf import settings
 from rest_framework.exceptions import PermissionDenied, ValidationError
 
 from apartment.elastic.queries import get_apartment_uuids
@@ -63,6 +64,9 @@ class ProjectApplicantValidator:
         project_uuid: UUID,
         date_of_birth_and_ssn_suffix: Union[Tuple[date, str], List[Tuple[date, str]]],
     ):
+        if getattr(settings, "APPLICANT_DUPLICATE_VALIDATION_DISABLED", False):
+            return
+
         if isinstance(date_of_birth_and_ssn_suffix, Tuple):
             date_of_birth_and_ssn_suffix = [date_of_birth_and_ssn_suffix]
         if isinstance(date_of_birth_and_ssn_suffix, List):


### PR DESCRIPTION
This is useful for testing, as it allows us to create multiple applications for the same applicant.

This is not allowed in production, as it would allow an applicant to submit multiple applications for the same apartment, but there was a bug that caused multiple applications for same applicant to be created even when the validation was enabled.  Therefore we now need this setting to be able to test situations where there are multiple applications for the same applicant.