### PR TITLE
queue fixer: Fix queue duplicate numbering issue

### DIFF
--- a/application_form/management/commands/fix_queue_positions_of_canceled_reservations.py
+++ b/application_form/management/commands/fix_queue_positions_of_canceled_reservations.py
@@ -84,6 +84,10 @@ class Command(BaseCommand):
     def fix(self, reservations_to_fix):
         for reservation in reservations_to_fix:
             print(f"Fixing {get_description(reservation)}...")
+            # Refresh reservation from DB to make sure we have the latest
+            # value of the queue_position field, since it might have been
+            # updated by previous iterations of this loop.
+            reservation.refresh_from_db()
             remove_reservation_from_queue(
                 reservation,
                 comment="Poistettu jonosta, koska oli peruttu ennen arvontaa",


### PR DESCRIPTION
The fix_queue_positions_of_canceled_reservations management command had an issue where it created duplicate queue numbers, because the reservations it updated in the loop were not refreshed from the database before they were used in the remove_reservation_from_queue call and that function reads the old queue position from the object.  When old queue position was used in the removal, it ended up changing queue positions incorrectly.

Fix the issue by refreshing the reservation from the database before removing it from the queue.