### PR TITLE
Fix reference number generator

### DIFF
--- a/invoicing/tests/test_utils.py
+++ b/invoicing/tests/test_utils.py
@@ -1,0 +1,15 @@
+import pytest
+
+from invoicing.utils import generate_reference_number
+
+
+@pytest.mark.parametrize(
+    "identifier, expected",
+    [
+        (118, "28251187"),
+        ("123456", "28251234568"),
+        (999, "28259998"),
+    ],
+)
+def test_generate_reference_number(identifier, expected):
+    assert generate_reference_number(identifier) == expected

--- a/invoicing/utils.py
+++ b/invoicing/utils.py
@@ -19,7 +19,7 @@ def generate_reference_number(identifier: Union[int, str]) -> str:
     coefficients = (7, 3, 1)
     check_digit = (
         10 - sum(int(d) * c for d, c in zip(reversed(actual), cycle(coefficients))) % 10
-    )
+    ) % 10
 
     return f"{actual}{check_digit}"
 


### PR DESCRIPTION
Reference number generator was giving the wrong reference number in some cases.
The condition :If the difference is 10, the checksum is 0 was missing.