### PR TITLE
Improve error handling for SAP transmissions lacking property numbers

### DIFF
--- a/invoicing/api/views.py
+++ b/invoicing/api/views.py
@@ -131,6 +131,18 @@ class ApartmentInstallmentAddToSapAPIView(APIView):
         if not installments.exists():
             raise Http404
 
+        # Check that all apartments have a property number
+        for installment in installments:
+            apartment = get_apartment(
+                installment.apartment_reservation.apartment_uuid,
+                include_project_fields=True,
+            )
+            property_number = getattr(apartment, "project_property_number", None)
+            if not property_number:
+                raise ValidationError(
+                    f"Apartment {apartment.title} does not have a property number."
+                )
+
         with transaction.atomic():
             for installment in installments:
                 try:


### PR DESCRIPTION
Enhance the error reporting mechanism during SAP data transmission by validating the presence of project property number in apartment installments.

Previously, the absence of property numbers would raise an error in XML generation but wouldn't be shown in the UI.

Now, missing property numbers trigger an error response in the API.

This ensures users are informed of data validation issues directly through the UI when the 'Send to SAP' button is pressed.