### PR TITLE
Fix rounding issues in revaluation calculations

### DIFF
--- a/cost_index/tests/test_cost_index_utils.py
+++ b/cost_index/tests/test_cost_index_utils.py
@@ -16,7 +16,7 @@ from cost_index.utils import calculate_end_value
 @mark.django_db
 def test_cost_index_utils_correct():
     cost_index_data = [
-        {"value": Decimal("100.00"), "valid_from": date(2022, 11, 23)},
+        {"value": Decimal("99.998"), "valid_from": date(2022, 11, 23)},
         {"value": Decimal("50.00"), "valid_from": date(2022, 11, 24)},
         {"value": Decimal("200.00"), "valid_from": date(2022, 11, 25)},
     ]
@@ -25,8 +25,8 @@ def test_cost_index_utils_correct():
 
     # Test the very basics
     assert calculate_end_value(
-        Decimal("100.00"), date(2022, 11, 23), date(2022, 11, 23)
-    ) == Decimal("100.00")
+        Decimal("99.989"), date(2022, 11, 23), date(2022, 11, 23)
+    ) == Decimal("99.99")
     assert calculate_end_value(
         Decimal("100.00"), date(2022, 11, 23), date(2022, 11, 24)
     ) == Decimal("50.00")
@@ -40,7 +40,7 @@ def test_cost_index_utils_correct():
     # Test rounding behaviour
     assert calculate_end_value(
         Decimal("100.01"), date(2022, 11, 23), date(2022, 11, 24)
-    ) == Decimal("50.00")
+    ) == Decimal("50.01")
 
     with pytest.raises(ValueError):
         calculate_end_value(Decimal("100.00"), date(1988, 11, 22), date(2022, 11, 23))

--- a/cost_index/utils.py
+++ b/cost_index/utils.py
@@ -1,6 +1,5 @@
-import math
 from datetime import date
-from decimal import Decimal
+from decimal import Decimal, ROUND_UP
 
 from cost_index.models import ApartmentRevaluation, CostIndex
 from invoicing.enums import InstallmentType
@@ -28,9 +27,7 @@ def determine_date_index(dt: date):
 
 def adjust_value(value: Decimal, start_index: Decimal, end_index: Decimal):
     adjusted_value = value / start_index * end_index
-
-    # Round to floor 2 decimals
-    return Decimal(math.floor(adjusted_value * 100)) / 100
+    return Decimal(adjusted_value).quantize(Decimal("0.01"), rounding=ROUND_UP)
 
 
 def current_right_of_occupancy_payment(


### PR DESCRIPTION
Solved an issue in the apartment revaluation calculations where costs were incorrectly rounded down instead of up, leading to a slight undervaluation.
The end-of-date apartment price was in cases  a cent lower than the start-of-date price due to this rounding error.

Updated the calculation to ensure rounding is up.