### PR TITLE
Improve Payment Sync Error Handling with SAP

### DIFF
--- a/invoicing/sap/fetch/process.py
+++ b/invoicing/sap/fetch/process.py
@@ -79,7 +79,7 @@ def process_payment_data(  # noqa: C901
                 invoice_number=invoice_number
             )
         except ApartmentInstallment.DoesNotExist:
-            errors.append(
+            logger.error(
                 f"{line_number}: ApartmentInstallment with invoice number "
                 f'"{invoice_number}" does not exist.'
             )

--- a/invoicing/tests/test_process_payment_data.py
+++ b/invoicing/tests/test_process_payment_data.py
@@ -25,8 +25,7 @@ INVALID_TEST_PAYMENT_DATA = """022121917199          12800     00000000000000000
 """  # noqa: E501, W291
 
 EXPECTED_ERROR_MESSAGE = """Parsing errors:
-2: Incorrect line length 6
-3: ApartmentInstallment with invoice number "730000077" does not exist."""  # noqa: E501, W291
+2: Incorrect line length 6"""  # noqa: E501, W291
 
 
 @pytest.mark.parametrize("has_filename", (True, False))


### PR DESCRIPTION
Before this update, payment synchronization with SAP would halt entirely if an invoice was not found, treating it as a critical error and preventing further updates.
This commit changes the error handling strategy: instead of raising an exception, it now logs a warning when an invoice is not found. This allows the synchronization process to continue and update the remaining payments successfully.