### PR TITLE
Fix create offer error

### DIFF
--- a/apartment/services.py
+++ b/apartment/services.py
@@ -87,7 +87,9 @@ Asumisoikeusasunnon vaihtaja: {_get_bool_str(reservation.is_right_of_occupancy_h
 """  # noqa: E501
 
 
-def _get_price_str(cents: int) -> str:
+def _get_price_str(cents: Optional[int]) -> str:
+    if cents is None:
+        cents = 0
     return (
         format((Decimal(cents) / 100).quantize(Decimal(".01")), ",")
         .replace(",", " ")


### PR DESCRIPTION
When creating an offer and the right_of_occupancy_deposit was missing the value was None and then calling the _get_price_str it would return None creating an error.
Fix the function so it would return 0 when the cents is None.