### PR TITLE
Fix lottery run when apartment is unlinked from project

### DIFF
--- a/application_form/services/lottery/hitas.py
+++ b/application_form/services/lottery/hitas.py
@@ -50,6 +50,8 @@ def _shuffle_applications(apartment_uuid: uuid.UUID) -> None:
     in random order.
     """
     apartment = get_apartment(apartment_uuid)
+    if not apartment:
+        return
     apartment_apps = ApplicationApartment.objects.filter(apartment_uuid=apartment_uuid)
 
     # If the apartment has enough rooms, applications with children should have priority


### PR DESCRIPTION
When running a lottery, the apartment uuids are fetched from a project.
If an apartment: has been unlinked from that project, it my still exists in Elasticsearch but not locally.
Fix this by checking if the apartment uuid exists.