### PR TITLE
Remove commas from filenames

### DIFF
--- a/application_form/api/sales/views.py
+++ b/application_form/api/sales/views.py
@@ -170,7 +170,9 @@ class ApartmentReservationViewSet(
         apartment = get_apartment(
             reservation.apartment_uuid, include_project_fields=True
         )
-        title = (apartment.title or "").strip().lower().replace(" ", "_")
+        title = (
+            (apartment.title or "").strip().lower().replace(" ", "_").replace(",", "")
+        )
 
         ownership_type = apartment.project_ownership_type.lower()
         if ownership_type == "hitas":
@@ -206,7 +208,9 @@ class ApartmentReservationViewSet(
         if not hasattr(reservation, "revaluation"):
             raise ValidationError("Reservation has no revaluation")
 
-        title = (apartment.title or "").strip().lower().replace(" ", "_")
+        title = (
+            (apartment.title or "").strip().lower().replace(" ", "_").replace(",", "")
+        )
         filename = f"haso_luovutuslaskelma{title}" if title else "haso_luovutuslaskelma"
 
         pdf_data = create_haso_release_pdf(

--- a/invoicing/api/views.py
+++ b/invoicing/api/views.py
@@ -94,7 +94,9 @@ class ApartmentInstallmentInvoiceAPIView(APIView):
 
         pdf_data = create_invoice_pdf_from_installments(installments)
         apartment = get_apartment(reservation.apartment_uuid)
-        title = (apartment.title or "").strip().lower().replace(" ", "_")
+        title = (
+            (apartment.title or "").strip().lower().replace(" ", "_").replace(",", "")
+        )
         filename = f"laskut_{title}.pdf" if title else "laskut.pdf"
 
         response = HttpResponse(pdf_data, content_type="application/pdf")


### PR DESCRIPTION
An error would occur when trying to download filenames that contain commas.
Remove commas from those filenames so that their Content-Disposition doesn't include commas.