### PR TITLE
Fix parsing of line when fetching payment amount

### DIFF
--- a/invoicing/sap/fetch/process.py
+++ b/invoicing/sap/fetch/process.py
@@ -21,6 +21,26 @@ class SapPaymentDataParsingError(Exception):
 
 
 class LineParser:
+    """
+     File format documentation for the LineParser
+    | Len | Pos| Description             | Example |
+    | --- | -- | ----------------------- |
+    | 1   | 0  | Record Id               | 3, 5, 7 |
+    | 14  | 1  | Account Number          |
+    | 6   | 15 | Registration Date       | YYMMDD  |
+    | 6   | 21 | Term                    | YYMMDD  |
+    | 16  | 27 | FillingID               |
+    | 20  | 43 | Reference               |
+    | 12  | 63 | Payer Name Abbreviation |
+    | 1   | 75 | Currency Unit Code      | 1 = Euro|
+    | 1   | 76 | Source of Name          | 1       |
+    | 10  | 77 | Amount                  | 8  + 2d |
+    | 1   | 87 | Adjustment Id           |
+    | 1   | 88 | Mode Of Transmission    |
+    | 1   | 89 | Feedback Code           |
+    Total lenght 90 characters
+    """
+
     def __init__(self, line: str):
         assert len(line) == 90, f"Incorrect line length {len(line)}"
         self.line = line
@@ -29,15 +49,15 @@ class LineParser:
         return self.line[index : index + length].strip()  # noqa: E203
 
     def get_payment_date(self) -> datetime.date:
-        return datetime.strptime(self.get_value_from_line(15, 6), "%d%m%y").date()
+        return datetime.strptime(self.get_value_from_line(15, 6), "%y%m%d").date()
 
     def get_amount(self) -> Decimal:
-        return Decimal(int(self.get_value_from_line(79, 10)) / Decimal("100")).quantize(
+        return Decimal(int(self.get_value_from_line(77, 10)) / Decimal("100")).quantize(
             Decimal(".01")
         )
 
     def get_invoice_number(self) -> int:
-        return int(self.get_value_from_line(27, 9))
+        return int(self.get_value_from_line(27, 16))
 
 
 @transaction.atomic

--- a/invoicing/tests/test_process_payment_data.py
+++ b/invoicing/tests/test_process_payment_data.py
@@ -12,8 +12,9 @@ from invoicing.sap.fetch import (
 from invoicing.tests.factories import ApartmentInstallmentFactory, PaymentFactory
 
 VALID_TEST_PAYMENT_DATA = """022121917199          12800     0000000000000000000000000000000000000000000000000000000000
-300000010700152221218221218730000077                           SAP ATestaaj1 00006658100  
-300000010700152221218221218730000077                           SAP BTestaaj1 00006658101  
+30000001070015222121822121863224                               SAP BTestaaj1 00006658101  
+30000001070015222121822121863224                               SAP ATestaaj1 00006658100  
+30000001011589724051024051063224                               Halotainen V1 00062905000  
 900000200001331620000000000000000000000000000000000000000000000000000000000000000000000000
 """  # noqa: E501, W291
 
@@ -31,7 +32,7 @@ EXPECTED_ERROR_MESSAGE = """Parsing errors:
 @pytest.mark.parametrize("has_filename", (True, False))
 @pytest.mark.django_db
 def test_read_payments_data(has_filename):
-    installment = ApartmentInstallmentFactory(invoice_number=730000077)
+    installment = ApartmentInstallmentFactory(invoice_number=63224)
     another_installment = ApartmentInstallmentFactory()
 
     if has_filename:
@@ -41,20 +42,22 @@ def test_read_payments_data(has_filename):
     else:
         num_of_payments = process_payment_data(VALID_TEST_PAYMENT_DATA)
 
-    assert installment.payments.count() == 2
-    payment_1, payment_2 = installment.payments.all()
-    assert payment_1.payment_date == date(2018, 12, 22)
-    assert payment_1.amount == Decimal("66581.00")
-    assert payment_2.payment_date == date(2018, 12, 22)
-    assert payment_2.amount == Decimal("66581.01")
+    assert installment.payments.count() == 3
+    payment_1, payment_2, payment_3 = installment.payments.all()
+    assert payment_1.payment_date == date(2022, 12, 18)
+    assert payment_1.amount == Decimal("6658.10")
+    assert payment_2.payment_date == date(2022, 12, 18)
+    assert payment_2.amount == Decimal("6658.10")
+    assert payment_3.payment_date == date(2024, 5, 10)
+    assert payment_3.amount == Decimal("62905.00")
     assert another_installment.payments.count() == 0
-    assert num_of_payments == 2
+    assert num_of_payments == 3
 
     if has_filename:
         assert PaymentBatch.objects.count() == 1
         batch = PaymentBatch.objects.first()
         assert batch.filename == "test_payments_123.txt"
-        assert list(batch.payments.all()) == [payment_1, payment_2]
+        assert list(batch.payments.all()) == [payment_1, payment_2, payment_3]
     else:
         assert PaymentBatch.objects.count() == 0
 


### PR DESCRIPTION
Previously, the parser misread the payment value, appending an extra zero. This was due to an incorrect parsing position within the string, which has the format ie:  00062905000.
The last digit are not part of the actual amount. The first 10 are.

The parser is now adjusted to move two positions to the left, correctly extracting the payment value, with the lenght of 10 characters.

Example of a payment line

`30000001011111111111111111111111                               Xxlxkxixxx V1 00062905000  
`
column 78 is where they payment starts so (77) for the array.
