### PR TITLE
Fix bug when adding a Hitas late reservation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,7 +91,7 @@ jobs:
           python-version: '3.8'
           cache: 'pip'
           cache-dependency-path: requirements-dev.txt
-
+  
       - name: Install app requirements
         run: pip install -r requirements.txt
         if: ${{ matrix.part == 'migrations' }}
@@ -148,7 +148,10 @@ jobs:
           python-version: ${{ matrix.python }}
           cache: 'pip'
           cache-dependency-path: requirements*.txt
-
+       
+      - name: Update apt packages
+        run: sudo apt-get update
+        
       - name: psycopg2 prerequisites
         run: sudo apt-get install libpq-dev
 

--- a/application_form/services/reservation.py
+++ b/application_form/services/reservation.py
@@ -108,11 +108,11 @@ def create_late_reservation(
         if user:
             reservation_data["handler"] = user.profile_or_user_full_name
 
-        ownership_type = apartment.project_ownership_type
+        ownership_type = apartment.project_ownership_type.lower()
         right_of_residence_ordering_number = get_right_of_residence_ordering_number(
             reservation_data
         )
-        if right_of_residence_ordering_number is None:
+        if right_of_residence_ordering_number is None and ownership_type == "haso":
             raise ValidationError("User has no right of residence number set")
 
         new_list_position, new_queue_position = calculate_new_positions(


### PR DESCRIPTION
When a reservation from a customer without right of residency number was added on Hitas apartments an error would occur.
Allow reservations from customers without right of residency numbers to be added on hitas apartments.
Reservations from haso apartments from users without right of residency number will still not be allowed.