### PR TITLE
Fix rounding for revaluations

### DIFF
--- a/cost_index/utils.py
+++ b/cost_index/utils.py
@@ -1,5 +1,5 @@
 from datetime import date
-from decimal import Decimal, ROUND_UP
+from decimal import Decimal, ROUND_HALF_UP
 
 from cost_index.models import ApartmentRevaluation, CostIndex
 from invoicing.enums import InstallmentType
@@ -27,7 +27,7 @@ def determine_date_index(dt: date):
 
 def adjust_value(value: Decimal, start_index: Decimal, end_index: Decimal):
     adjusted_value = value / start_index * end_index
-    return Decimal(adjusted_value).quantize(Decimal("0.01"), rounding=ROUND_UP)
+    return Decimal(adjusted_value).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
 
 
 def current_right_of_occupancy_payment(


### PR DESCRIPTION
Before the rounding was ROUND_UP which was incorrect, the correct way us ROUND_HALF_UP which will round a number to the nearest. Ei 1.055 to 1.06 and 1.054 to 1.05