### PR TITLE
Fix reservations when offer is done

### DIFF
--- a/application_form/services/offer.py
+++ b/application_form/services/offer.py
@@ -107,7 +107,11 @@ def update_other_customer_reservations_states(reservation):
     other_reservations = ApartmentReservation.objects.filter(
         apartment_uuid__in=get_apartment_uuids(apartment.project_uuid),
         customer=reservation.customer,
-    ).exclude(Q(state=ApartmentReservationState.CANCELED) | Q(id=reservation.id))
+    ).exclude(
+        Q(state=ApartmentReservationState.CANCELED)
+        | Q(id=reservation.id)
+        | Q(state=ApartmentReservationState.SOLD)
+    )
     for reservation in other_reservations:
         cancel_reservation(
             reservation,


### PR DESCRIPTION
When a customer is offered an apartment in a project, there’s an automatic system that cancels any other reservations the customer has for apartments in the same project. However, if any of the other apartments the customer reserved are already sold to them, those reservations should not be canceled. Only the unsold apartments should be removed from their reservations.