### PR TITLE
Add API for latest application's applicant

### DIFF
--- a/application_form/api/sales/serializers.py
+++ b/application_form/api/sales/serializers.py
@@ -38,6 +38,9 @@ class ProjectUUIDSerializer(serializers.Serializer):
 
 
 class SalesApplicantSerializer(ApplicantSerializerBase):
+    class Meta(ApplicantSerializerBase.Meta):
+        fields = ApplicantSerializerBase.Meta.fields + ["date_of_birth", "ssn_suffix"]
+
     pass
 
 
@@ -45,10 +48,11 @@ class SalesApplicationSerializer(ApplicationSerializerBase):
     profile = serializers.PrimaryKeyRelatedField(
         queryset=Profile.objects.all(), write_only=True
     )
+    applicant = SalesApplicantSerializer(write_only=True)
     additional_applicant = SalesApplicantSerializer(write_only=True, allow_null=True)
 
     class Meta(ApplicationSerializerBase.Meta):
-        fields = ApplicationSerializerBase.Meta.fields + ("profile",)
+        fields = ApplicationSerializerBase.Meta.fields + ("profile", "applicant")
 
     def _get_senders_name_from_applicants_data(self, validated_data):
         additional_applicant = validated_data.get("additional_applicant")

--- a/application_form/services/application.py
+++ b/application_form/services/application.py
@@ -91,7 +91,8 @@ def create_application(
     )
     data = application_data.copy()
     profile = data.pop("profile")
-    additional_applicant_data = data.pop("additional_applicant")
+    applicant_data = data.pop("applicant")
+    additional_applicant_data = data.pop("additional_applicant", None)
     customer = get_or_create_customer_from_profiles(
         profile, additional_applicant_data, data.get("has_children")
     )
@@ -116,17 +117,19 @@ def create_application(
         sender_names=data.pop("sender_names"),
     )
     Applicant.objects.create(
-        first_name=profile.first_name,
-        last_name=profile.last_name,
-        email=profile.email,
-        phone_number=profile.phone_number,
-        street_address=profile.street_address,
-        city=profile.city,
-        postal_code=profile.postal_code,
-        age=_calculate_age(profile.date_of_birth),
-        date_of_birth=profile.date_of_birth,
-        ssn_suffix=application_data["ssn_suffix"],
-        contact_language=profile.contact_language,
+        first_name=applicant_data["first_name"],
+        last_name=applicant_data["last_name"],
+        email=applicant_data["email"],
+        phone_number=applicant_data["phone_number"],
+        street_address=applicant_data["street_address"],
+        city=applicant_data["city"],
+        postal_code=applicant_data["postal_code"],
+        age=_calculate_age(applicant_data["date_of_birth"]),
+        date_of_birth=applicant_data["date_of_birth"],
+        ssn_suffix=applicant_data["ssn_suffix"],
+        contact_language=applicant_data.get(
+            "contact_language", profile.contact_language
+        ),
         is_primary_applicant=True,
         application=application,
     )
@@ -166,7 +169,7 @@ def update_profile_from_application_data(profile: Profile, data: dict) -> None:
     Currently only fills the ssn_suffix field if it's empty in the
     profile.
     """
-    ssn_suffix = data.get("ssn_suffix")
+    ssn_suffix = data.get("applicant", {}).get("ssn_suffix")
     if not profile.ssn_suffix and ssn_suffix:
         profile.ssn_suffix = ssn_suffix
         profile.save(update_fields=["ssn_suffix"])

--- a/application_form/tests/conftest.py
+++ b/application_form/tests/conftest.py
@@ -243,15 +243,24 @@ def create_application_data(
         for index, apartment_uuid in enumerate(apartment_uuids[0:5])
     ]
     right_of_residence = 123456 if application_type == ApplicationType.HASO else None
-
     # Build application request data
     application_data = {
         "application_uuid": str(uuid.uuid4()),
         "application_type": application_type.value,
-        "ssn_suffix": profile.ssn_suffix,
         "has_children": True,
         "right_of_residence": right_of_residence,
         "additional_applicant": None,
+        "applicant": {
+            "first_name": profile.first_name,
+            "last_name": profile.last_name,
+            "email": profile.email,
+            "street_address": profile.street_address,
+            "postal_code": profile.postal_code,
+            "city": profile.city,
+            "phone_number": profile.phone_number,
+            "date_of_birth": profile.date_of_birth,
+            "ssn_suffix": profile.ssn_suffix,
+        },
         "project_id": str(project_uuid),
         "apartments": apartments_data,
         "has_hitas_ownership": True,
@@ -260,15 +269,15 @@ def create_application_data(
     # Add a second applicant if needed
     if num_applicants == 2:
         date_of_birth = faker.Faker().date_of_birth(minimum_age=18)
-        applicant = ApplicantFactory.build()
+        additional_applicant = ApplicantFactory.build()
         application_data["additional_applicant"] = {
-            "first_name": applicant.first_name,
-            "last_name": applicant.last_name,
-            "email": applicant.email,
-            "street_address": applicant.street_address,
-            "postal_code": applicant.postal_code,
-            "city": applicant.city,
-            "phone_number": applicant.phone_number,
+            "first_name": additional_applicant.first_name,
+            "last_name": additional_applicant.last_name,
+            "email": additional_applicant.email,
+            "street_address": additional_applicant.street_address,
+            "postal_code": additional_applicant.postal_code,
+            "city": additional_applicant.city,
+            "phone_number": additional_applicant.phone_number,
             "date_of_birth": f"{date_of_birth:%Y-%m-%d}",
             "ssn_suffix": calculate_ssn_suffix(date_of_birth),
         }

--- a/application_form/tests/test_application_api.py
+++ b/application_form/tests/test_application_api.py
@@ -70,7 +70,7 @@ def test_application_post_sets_nin(api_client, elastic_single_project_with_apart
     assert response.status_code == 201
     assert response.data == {"application_uuid": data["application_uuid"]}
     profile.refresh_from_db()
-    assert profile.ssn_suffix == data["ssn_suffix"]
+    assert profile.ssn_suffix == data["applicant"]["ssn_suffix"]
     assert len(profile.national_identification_number) == 11
 
 
@@ -212,14 +212,14 @@ def test_application_post_fails_if_incorrect_ssn_suffix(
     profile = ProfileFactory()
     api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {_create_token(profile)}")
     data = create_application_data(profile)
-    data["ssn_suffix"] = "-000$"
+    data["applicant"]["ssn_suffix"] = "-000$"
     response = api_client.post(
         reverse("application_form:application-list"), data, format="json"
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert len(response.data["ssn_suffix"][0]["message"]) > 0
+    assert len(response.data["applicant"]["ssn_suffix"][0]["message"]) > 0
     assert (
-        response.data["ssn_suffix"][0]["code"]
+        response.data["applicant"]["ssn_suffix"][0]["code"]
         == error_codes.E1000_SSN_SUFFIX_IS_NOT_VALID
     )
 
@@ -350,9 +350,9 @@ def test_application_post_fails_if_partner_profile_have_already_applied_to_proje
         ).date(),
     )
     partner_application_data = create_application_data(partner_profile)
-    partner_application_data["ssn_suffix"] = application_data["additional_applicant"][
-        "ssn_suffix"
-    ]
+    partner_application_data["applicant"]["ssn_suffix"] = application_data[
+        "additional_applicant"
+    ]["ssn_suffix"]
     api_client.credentials(
         HTTP_AUTHORIZATION=f"Bearer {_create_token(partner_profile)}"
     )

--- a/application_form/tests/test_sales_application_api.py
+++ b/application_form/tests/test_sales_application_api.py
@@ -48,7 +48,7 @@ def test_sales_application_post(
     )
     data = create_application_data(customer_profile)
     data["profile"] = customer_profile.id
-    data["ssn_suffix"] = "XXXXX"  # ssn suffix should not be validated
+    data["applicant"]["ssn_suffix"] = "XXXXX"  # ssn suffix should not be validated
     data["additional_applicant"]["ssn_suffix"] = "XXXXX"
     response = drupal_salesperson_api_client.post(
         reverse("application_form:sales-application-list"), data, format="json"

--- a/application_form/urls.py
+++ b/application_form/urls.py
@@ -8,7 +8,11 @@ from application_form.api.sales.views import (
     OfferViewSet,
     SalesApplicationViewSet,
 )
-from application_form.api.views import ApplicationViewSet, ListProjectReservations
+from application_form.api.views import (
+    ApplicationViewSet,
+    LatestApplicantInfo,
+    ListProjectReservations,
+)
 from invoicing.api.views import (
     ApartmentInstallmentAddToSapAPIView,
     ApartmentInstallmentAPIView,
@@ -69,6 +73,11 @@ urlpatterns = [
         r"sales/apartment_states/",
         apartment_states,
         name="apartment_states",
+    ),
+    path(
+        r"sales/applicant/latest/<int:customer_id>/",
+        LatestApplicantInfo.as_view(),
+        name="applicant-by-customer",
     ),
     path("", include(router.urls)),
 ]


### PR DESCRIPTION
In order to make accesible the latest applicant's address information added the API endpoint.
Save applicantion's address to application instead of using the profile address, this change was needed when the user would delete his address from his profile making it unaccesible from the application.