### PR TITLE
Remove error when user has no application

### DIFF
--- a/application_form/api/views.py
+++ b/application_form/api/views.py
@@ -52,9 +52,13 @@ class LatestApplicantInfo(GenericAPIView):
     http_method_names = ["get"]
 
     def get(self, request, customer_id):
-        application = Application.objects.filter(customer__id=customer_id).latest(
-            "created_at"
-        )
+        try:
+            application = Application.objects.filter(customer__id=customer_id).latest(
+                "created_at"
+            )
+        except Application.DoesNotExist:
+            application = None
+
         if application:
             applicant = application.applicants.filter(is_primary_applicant=True).first()
             if applicant:


### PR DESCRIPTION
Prevent error when fetching latest applicant information for users without applications by returning empty object instead so ui won't display any error.