### PR TITLE
Asu 1745 fix tests

### DIFF
--- a/apartment/elastic/elastic_utils.py
+++ b/apartment/elastic/elastic_utils.py
@@ -1,5 +1,6 @@
 # apartment/elastic/utils.py
 import functools
+
 from django.conf import settings
 from elasticsearch_dsl import connections
 

--- a/apartment/elastic/elastic_utils.py
+++ b/apartment/elastic/elastic_utils.py
@@ -1,6 +1,6 @@
 # apartment/elastic/utils.py
 import functools
-
+from django.conf import settings
 from elasticsearch_dsl import connections
 
 
@@ -11,6 +11,10 @@ def get_es_mapping(index_name="asuntotuotanto_apartment"):
 
 
 def resolve_es_field(field_name: str, index_name="asuntotuotanto_apartment") -> str:
+    # use test index when running tests
+    if settings.IS_TEST:
+        index_name = settings.TEST_APARTMENT_INDEX_NAME
+
     mapping = get_es_mapping(index_name)
     props = mapping[index_name]["mappings"]["properties"]
 


### PR DESCRIPTION
Tests are run using its own ElasticSearch instance and it only has the index set with value `TEST_APARTMENT_INDEX_NAME` in `.env` file. Use this when running tests.