### PR TITLE
Fix KeyError when "right_of_occupancy_payment" is empty

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ env:
   APARTMENT_DATA_TRANSFER_PATH: test_files
   # poppler-utils package contains the pdftotext-program that is used in some tests
   # newer versions of the program parse PDF's differently causing the tests to fail
-  POPPLER_UTILS_VERSION: '22.02.0-2ubuntu0.7'
+  POPPLER_UTILS_VERSION: '22.02.0-2ubuntu0.8'
   GETTEXT_VERSION: '0.21-4ubuntu4'
   PUBLIC_PGP_KEY: |
     -----BEGIN PGP PUBLIC KEY BLOCK-----

--- a/invoicing/models.py
+++ b/invoicing/models.py
@@ -250,22 +250,16 @@ class ProjectInstallmentTemplate(InstallmentBase):
         elif ps == InstallmentPercentageSpecifier.SALES_PRICE:
             # hotfix for ASU-1752, use default value in case Elasticsearch returns None
             # for the attribute. This means its likely empty in Drupal too
-            try:
-                price_in_cents = apartment_data["sales_price"]
-            except KeyError:
-                price_in_cents = Decimal(0)
+            price_in_cents = apartment_data.sales_price
         elif ps == InstallmentPercentageSpecifier.DEBT_FREE_SALES_PRICE:
-            try:
-                price_in_cents = apartment_data["debt_free_sales_price"]
-            except KeyError:
-                price_in_cents = Decimal(0)
+            price_in_cents = apartment_data.debt_free_sales_price
         elif ps == InstallmentPercentageSpecifier.RIGHT_OF_OCCUPANCY_PAYMENT:
-            try:
-                price_in_cents = apartment_data["right_of_occupancy_payment"]
-            except KeyError:
-                price_in_cents = Decimal(0)
+            price_in_cents = apartment_data.right_of_occupancy_payment
         else:
             assert_never(ps)
+
+        if not price_in_cents:
+            price_in_cents = Decimal(0)
 
         if self.is_numbered_payment():
             price_rounding = PriceRounding.EUROS

--- a/invoicing/models.py
+++ b/invoicing/models.py
@@ -254,7 +254,9 @@ class ProjectInstallmentTemplate(InstallmentBase):
         elif ps == InstallmentPercentageSpecifier.DEBT_FREE_SALES_PRICE:
             price_in_cents = apartment_data.get("debt_free_sales_price", Decimal(0))
         elif ps == InstallmentPercentageSpecifier.RIGHT_OF_OCCUPANCY_PAYMENT:
-            price_in_cents = apartment_data.get("right_of_occupancy_payment", Decimal(0))
+            price_in_cents = apartment_data.get(
+                "right_of_occupancy_payment", Decimal(0)
+            )
         else:
             assert_never(ps)
 

--- a/invoicing/models.py
+++ b/invoicing/models.py
@@ -250,13 +250,20 @@ class ProjectInstallmentTemplate(InstallmentBase):
         elif ps == InstallmentPercentageSpecifier.SALES_PRICE:
             # hotfix for ASU-1752, use default value in case Elasticsearch returns None
             # for the attribute. This means its likely empty in Drupal too
-            price_in_cents = apartment_data.get("sales_price", Decimal(0))
+            try:
+                price_in_cents = apartment_data["sales_price"]
+            except KeyError:
+                price_in_cents = Decimal(0)
         elif ps == InstallmentPercentageSpecifier.DEBT_FREE_SALES_PRICE:
-            price_in_cents = apartment_data.get("debt_free_sales_price", Decimal(0))
+            try:
+                price_in_cents = apartment_data["debt_free_sales_price"]
+            except KeyError:
+                price_in_cents = Decimal(0)
         elif ps == InstallmentPercentageSpecifier.RIGHT_OF_OCCUPANCY_PAYMENT:
-            price_in_cents = apartment_data.get(
-                "right_of_occupancy_payment", Decimal(0)
-            )
+            try:
+                price_in_cents = apartment_data["right_of_occupancy_payment"]
+            except KeyError:
+                price_in_cents = Decimal(0)
         else:
             assert_never(ps)
 

--- a/invoicing/models.py
+++ b/invoicing/models.py
@@ -242,6 +242,7 @@ class ProjectInstallmentTemplate(InstallmentBase):
 
     def _get_value_from_percentage(self, apartment_data) -> Decimal:
         ps: InstallmentPercentageSpecifier = self.percentage_specifier
+
         if ps == InstallmentPercentageSpecifier.SALES_PRICE_FLEXIBLE:
             # flexible payment's value will be populated later based on the other
             # installments of the same apartment
@@ -249,11 +250,11 @@ class ProjectInstallmentTemplate(InstallmentBase):
         elif ps == InstallmentPercentageSpecifier.SALES_PRICE:
             # hotfix for ASU-1752, use default value in case Elasticsearch returns None
             # for the attribute. This means its likely empty in Drupal too
-            price_in_cents = apartment_data.get("sales_price", 0)
+            price_in_cents = apartment_data.get("sales_price", Decimal(0))
         elif ps == InstallmentPercentageSpecifier.DEBT_FREE_SALES_PRICE:
-            price_in_cents = apartment_data.get("debt_free_sales_price", 0)
+            price_in_cents = apartment_data.get("debt_free_sales_price", Decimal(0))
         elif ps == InstallmentPercentageSpecifier.RIGHT_OF_OCCUPANCY_PAYMENT:
-            price_in_cents = apartment_data.get("right_of_occupancy_payment", 0)
+            price_in_cents = apartment_data.get("right_of_occupancy_payment", Decimal(0))
         else:
             assert_never(ps)
 

--- a/invoicing/models.py
+++ b/invoicing/models.py
@@ -247,11 +247,13 @@ class ProjectInstallmentTemplate(InstallmentBase):
             # installments of the same apartment
             return Decimal(0)
         elif ps == InstallmentPercentageSpecifier.SALES_PRICE:
-            price_in_cents = apartment_data["sales_price"]
+            # hotfix for ASU-1752, use default value in case Elasticsearch returns None
+            # for the attribute. This means its likely empty in Drupal too
+            price_in_cents = apartment_data.get("sales_price", 0)
         elif ps == InstallmentPercentageSpecifier.DEBT_FREE_SALES_PRICE:
-            price_in_cents = apartment_data["debt_free_sales_price"]
+            price_in_cents = apartment_data.get("debt_free_sales_price", 0)
         elif ps == InstallmentPercentageSpecifier.RIGHT_OF_OCCUPANCY_PAYMENT:
-            price_in_cents = apartment_data["right_of_occupancy_payment"]
+            price_in_cents = apartment_data.get("right_of_occupancy_payment", 0)
         else:
             assert_never(ps)
 


### PR DESCRIPTION
`ProjectInstallmentTemplate. _get_value_from_percentage(self, apartment_data)` returns default value of Decimal(0) if `"sales_price"`, `"debt_free_sales_price"` or `"right_of_occupancy_payment"` attributes on `ApartmentDocument` obj are None