### PR TITLE
Change criteria for Etuovi export. Exclude apartments where `apartment_state_of_sale` is `SOLD`

### DIFF
--- a/connections/etuovi/services.py
+++ b/connections/etuovi/services.py
@@ -19,7 +19,7 @@ def fetch_apartments_for_sale(verbose: bool = False) -> list:
     s_obj = (
         ApartmentDocument.search()
         .filter("term", _language="fi")
-        .filter("term", apartment_state_of_sale__keyword=ApartmentStateOfSale.FOR_SALE)
+        .exclude("term", apartment_state_of_sale__keyword=ApartmentStateOfSale.SOLD)
         .filter("term", publish_on_etuovi=True)
     )
     s_obj.execute()


### PR DESCRIPTION
Previously only included apartments where `apartment_state_of_sale` was `ApartmentStateOfSale.FOR_SALE`