### PR TITLE
ASU-1891: Skip duplicate image urls in Oikotie export, cap to 100

### DIFF
--- a/application_form/tests/test_locked_reservation_protection.py
+++ b/application_form/tests/test_locked_reservation_protection.py
@@ -110,12 +110,12 @@ def test_reserve_haso_apartment_does_not_downgrade_sold_winner(
     _reserve_haso_apartment(apartment_uuid)
 
     winner.refresh_from_db()
-    assert winner.state == ApartmentReservationState.SOLD, (
-        "SOLD winner was downgraded by _reserve_haso_apartment"
-    )
-    assert winner.state_change_events.count() == events_before, (
-        "No new state-change event should be created for the sold winner"
-    )
+    assert (
+        winner.state == ApartmentReservationState.SOLD
+    ), "SOLD winner was downgraded by _reserve_haso_apartment"
+    assert (
+        winner.state_change_events.count() == events_before
+    ), "No new state-change event should be created for the sold winner"
 
 
 @mark.django_db
@@ -150,12 +150,12 @@ def test_reserve_apartment_hitas_does_not_downgrade_sold_winner(
     _reserve_apartment(apartment_uuid)
 
     winner.refresh_from_db()
-    assert winner.state == ApartmentReservationState.SOLD, (
-        "SOLD HITAS winner was downgraded by _reserve_apartment"
-    )
-    assert winner.state_change_events.count() == events_before, (
-        "No new state-change event should be created for the sold winner"
-    )
+    assert (
+        winner.state == ApartmentReservationState.SOLD
+    ), "SOLD HITAS winner was downgraded by _reserve_apartment"
+    assert (
+        winner.state_change_events.count() == events_before
+    ), "No new state-change event should be created for the sold winner"
 
 
 @mark.django_db
@@ -186,9 +186,9 @@ def test_cancel_reservation_in_same_apartment_does_not_downgrade_sold_winner_has
         "Cancelling a reservation behind a SOLD winner must not downgrade "
         "the SOLD reservation"
     )
-    assert sold_winner.state_change_events.count() == events_before, (
-        "No new state-change event should be created for the SOLD reservation"
-    )
+    assert (
+        sold_winner.state_change_events.count() == events_before
+    ), "No new state-change event should be created for the SOLD reservation"
 
 
 @mark.django_db
@@ -203,9 +203,7 @@ def test_distribute_haso_apartments_is_idempotent_after_sale(
     apartment_uuid = apartments[0].uuid
 
     app = ApplicationFactory(type=ApplicationType.HASO, right_of_residence=1)
-    app.application_apartments.create(
-        apartment_uuid=apartment_uuid, priority_number=0
-    )
+    app.application_apartments.create(apartment_uuid=apartment_uuid, priority_number=0)
     add_application_to_queues(app)
     _distribute_haso_apartments(project_uuid)
 
@@ -221,9 +219,9 @@ def test_distribute_haso_apartments_is_idempotent_after_sale(
     _distribute_haso_apartments(project_uuid)
 
     reservation.refresh_from_db()
-    assert reservation.state == ApartmentReservationState.SOLD, (
-        "Re-running HASO lottery must not downgrade SOLD reservations"
-    )
+    assert (
+        reservation.state == ApartmentReservationState.SOLD
+    ), "Re-running HASO lottery must not downgrade SOLD reservations"
     assert reservation.state_change_events.count() == events_before, (
         "Re-running lottery must not produce a new state-change event on a "
         "sold reservation"
@@ -330,9 +328,7 @@ def test_late_haso_application_does_not_downgrade_sold_winner_in_other_apartment
 
     # Customer Y's prior reservation on the sold apartment must be CANCELED.
     customer_y_reservation_on_sold.refresh_from_db()
-    assert (
-        customer_y_reservation_on_sold.state == ApartmentReservationState.CANCELED
-    )
+    assert customer_y_reservation_on_sold.state == ApartmentReservationState.CANCELED
 
     # The actual regression assertion: the unrelated SOLD reservation on the same
     # apartment must NOT have been downgraded by the cancel cascade.
@@ -341,6 +337,6 @@ def test_late_haso_application_does_not_downgrade_sold_winner_in_other_apartment
         "Late application's cancel cascade downgraded a SOLD reservation on "
         "another apartment in the project"
     )
-    assert sold_reservation.state_change_events.count() == sold_events_before, (
-        "No new state-change event should be written on the SOLD reservation"
-    )
+    assert (
+        sold_reservation.state_change_events.count() == sold_events_before
+    ), "No new state-change event should be written on the SOLD reservation"

--- a/application_form/tests/test_locked_reservation_protection.py
+++ b/application_form/tests/test_locked_reservation_protection.py
@@ -28,9 +28,9 @@ from application_form.enums import (
 )
 from application_form.models import ApartmentReservation, Application
 from application_form.services.application import (
-    cancel_reservation,
     _reserve_apartment,
     _reserve_haso_apartment,
+    cancel_reservation,
 )
 from application_form.services.lottery.haso import _distribute_haso_apartments
 from application_form.services.queue import add_application_to_queues

--- a/connections/oikotie/oikotie_mapper.py
+++ b/connections/oikotie/oikotie_mapper.py
@@ -57,6 +57,9 @@ from connections.utils import convert_price_from_cents_to_eur
 
 _logger = logging.getLogger(__name__)
 
+# Oikotie apartments batch schema allows Picture1 through Picture100 only.
+OIKOTIE_MAX_PICTURES = 100
+
 
 def ensure_str(
     value: Union[str, AttrList, None], multi_join: bool = False
@@ -148,44 +151,49 @@ def map_estate(elastic_apartment: ElasticApartment) -> Optional[Estate]:
 def map_apartment_pictures(
     elastic_apartment: ElasticApartment,
 ) -> List[ApartmentPicture]:
-    pictures = []
+    """
+    Map apartment images for Oikotie export.
+
+    Deduplicates URLs and caps output at OIKOTIE_MAX_PICTURES to satisfy the
+    Oikotie RELAXNG schema.
+    """
+    candidates: List[tuple[str, bool]] = []
 
     main_image_url = ensure_str(
         getattr(elastic_apartment, "project_main_image_url", None)
     )
     if main_image_url:
-        pictures.append(
-            ApartmentPicture(
-                index=len(pictures) + 1,
-                is_floor_plan=False,
-                url=main_image_url,
-            )
-        )
+        candidates.append((main_image_url, False))
 
     image_urls = [
         *getattr(elastic_apartment, "image_urls", []),
         *getattr(elastic_apartment, "project_image_urls", []),
     ]
-    if len(image_urls) > 0:
-        for picture_url in image_urls:
-            url = ensure_str(picture_url)
-            if url:
-                pictures.append(
-                    ApartmentPicture(
-                        index=len(pictures) + 1,
-                        is_floor_plan=False,
-                        url=url,
-                    )
-                )
+    for picture_url in image_urls:
+        url = ensure_str(picture_url)
+        if url:
+            candidates.append((url, False))
+
     floor_plan_image = ensure_str(getattr(elastic_apartment, "floor_plan_image", None))
     if floor_plan_image:
+        candidates.append((floor_plan_image, True))
+
+    seen_urls: set[str] = set()
+    pictures: List[ApartmentPicture] = []
+    for url, is_floor_plan in candidates:
+        if url in seen_urls:
+            continue
+        seen_urls.add(url)
         pictures.append(
             ApartmentPicture(
                 index=len(pictures) + 1,
-                is_floor_plan=True,
-                url=floor_plan_image,
+                is_floor_plan=is_floor_plan,
+                url=url,
             )
         )
+        if len(pictures) >= OIKOTIE_MAX_PICTURES:
+            break
+
     return pictures
 
 

--- a/connections/tests/test_oikotie.py
+++ b/connections/tests/test_oikotie.py
@@ -268,6 +268,46 @@ class TestOikotieMapper:
         )
         assert mapped_apartment.pictures[1].is_floor_plan is True
 
+    def test_elastic_to_oikotie__pictures__deduplicates_repeated_urls(self):
+        """
+        - Duplicate image_urls from ES are mapped once.
+        - Order of first occurrence is preserved.
+        """
+        repeated_url = "https://test.example.com/repeated.jpg"
+        elastic_apartment = ApartmentDocumentFactory(
+            project_main_image_url="https://test.example.com/main.jpg",
+            project_image_urls=[repeated_url] * 300,
+            image_urls=[repeated_url] * 300,
+            floor_plan_image=None,
+        )
+        pictures = map_apartment_pictures(elastic_apartment)
+
+        assert len(pictures) == 2
+        assert pictures[0].url == "https://test.example.com/main.jpg"
+        assert pictures[1].url == repeated_url
+        assert [picture.index for picture in pictures] == [1, 2]
+
+    def test_elastic_to_oikotie__pictures__caps_at_oikotie_schema_max(self):
+        """
+        - Oikotie schema allows Picture1 through Picture100 only.
+        - URLs beyond the limit are dropped.
+        """
+        unique_urls = [
+            f"https://test.example.com/image-{index}.jpg" for index in range(101)
+        ]
+        elastic_apartment = ApartmentDocumentFactory(
+            project_main_image_url=None,
+            project_image_urls=[],
+            image_urls=unique_urls,
+            floor_plan_image=None,
+        )
+        pictures = map_apartment_pictures(elastic_apartment)
+
+        assert len(pictures) == 100
+        assert pictures[0].url == "https://test.example.com/image-0.jpg"
+        assert pictures[99].url == "https://test.example.com/image-99.jpg"
+        assert [picture.index for picture in pictures] == list(range(1, 101))
+
     def test_elastic_to_oikotie__real_estate_agent__mapping_types(self):
         elastic_apartment = ApartmentDocumentFactory()
         oikotie_real_estate_agent = map_real_estate_agent(elastic_apartment)


### PR DESCRIPTION
- Bug in Drupal causes `ApartmentDocument.image_urls` to grow up to over a 1000 repetitive urls [link to bug in source](https://github.com/City-of-Helsinki/drupal-asuntotuotanto/blob/develop/public/modules/custom/asu_content/src/Plugin/ComputedField/ApartmentImages.php#L70-L103)