### PR TITLE
Hotfix 2026-06-01

### DIFF
--- a/connections/oikotie/oikotie_mapper.py
+++ b/connections/oikotie/oikotie_mapper.py
@@ -57,6 +57,9 @@ from connections.utils import convert_price_from_cents_to_eur
 
 _logger = logging.getLogger(__name__)
 
+# Oikotie apartments batch schema allows Picture1 through Picture100 only.
+OIKOTIE_MAX_PICTURES = 100
+
 
 def ensure_str(
     value: Union[str, AttrList, None], multi_join: bool = False
@@ -148,44 +151,49 @@ def map_estate(elastic_apartment: ElasticApartment) -> Optional[Estate]:
 def map_apartment_pictures(
     elastic_apartment: ElasticApartment,
 ) -> List[ApartmentPicture]:
-    pictures = []
+    """
+    Map apartment images for Oikotie export.
+
+    Deduplicates URLs and caps output at OIKOTIE_MAX_PICTURES to satisfy the
+    Oikotie RELAXNG schema.
+    """
+    candidates: List[tuple[str, bool]] = []
 
     main_image_url = ensure_str(
         getattr(elastic_apartment, "project_main_image_url", None)
     )
     if main_image_url:
-        pictures.append(
-            ApartmentPicture(
-                index=len(pictures) + 1,
-                is_floor_plan=False,
-                url=main_image_url,
-            )
-        )
+        candidates.append((main_image_url, False))
 
     image_urls = [
         *getattr(elastic_apartment, "image_urls", []),
         *getattr(elastic_apartment, "project_image_urls", []),
     ]
-    if len(image_urls) > 0:
-        for picture_url in image_urls:
-            url = ensure_str(picture_url)
-            if url:
-                pictures.append(
-                    ApartmentPicture(
-                        index=len(pictures) + 1,
-                        is_floor_plan=False,
-                        url=url,
-                    )
-                )
+    for picture_url in image_urls:
+        url = ensure_str(picture_url)
+        if url:
+            candidates.append((url, False))
+
     floor_plan_image = ensure_str(getattr(elastic_apartment, "floor_plan_image", None))
     if floor_plan_image:
+        candidates.append((floor_plan_image, True))
+
+    seen_urls: set[str] = set()
+    pictures: List[ApartmentPicture] = []
+    for url, is_floor_plan in candidates:
+        if url in seen_urls:
+            continue
+        seen_urls.add(url)
         pictures.append(
             ApartmentPicture(
                 index=len(pictures) + 1,
-                is_floor_plan=True,
-                url=floor_plan_image,
+                is_floor_plan=is_floor_plan,
+                url=url,
             )
         )
+        if len(pictures) >= OIKOTIE_MAX_PICTURES:
+            break
+
     return pictures
 
 

--- a/connections/tests/test_oikotie.py
+++ b/connections/tests/test_oikotie.py
@@ -264,6 +264,46 @@ class TestOikotieMapper:
         )
         assert mapped_apartment.pictures[1].is_floor_plan is True
 
+    def test_elastic_to_oikotie__pictures__deduplicates_repeated_urls(self):
+        """
+        - Duplicate image_urls from ES are mapped once.
+        - Order of first occurrence is preserved.
+        """
+        repeated_url = "https://test.example.com/repeated.jpg"
+        elastic_apartment = ApartmentDocumentFactory(
+            project_main_image_url="https://test.example.com/main.jpg",
+            project_image_urls=[repeated_url] * 300,
+            image_urls=[repeated_url] * 300,
+            floor_plan_image=None,
+        )
+        pictures = map_apartment_pictures(elastic_apartment)
+
+        assert len(pictures) == 2
+        assert pictures[0].url == "https://test.example.com/main.jpg"
+        assert pictures[1].url == repeated_url
+        assert [picture.index for picture in pictures] == [1, 2]
+
+    def test_elastic_to_oikotie__pictures__caps_at_oikotie_schema_max(self):
+        """
+        - Oikotie schema allows Picture1 through Picture100 only.
+        - URLs beyond the limit are dropped.
+        """
+        unique_urls = [
+            f"https://test.example.com/image-{index}.jpg" for index in range(101)
+        ]
+        elastic_apartment = ApartmentDocumentFactory(
+            project_main_image_url=None,
+            project_image_urls=[],
+            image_urls=unique_urls,
+            floor_plan_image=None,
+        )
+        pictures = map_apartment_pictures(elastic_apartment)
+
+        assert len(pictures) == 100
+        assert pictures[0].url == "https://test.example.com/image-0.jpg"
+        assert pictures[99].url == "https://test.example.com/image-99.jpg"
+        assert [picture.index for picture in pictures] == list(range(1, 101))
+
     def test_elastic_to_oikotie__real_estate_agent__mapping_types(self):
         elastic_apartment = ApartmentDocumentFactory()
         oikotie_real_estate_agent = map_real_estate_agent(elastic_apartment)


### PR DESCRIPTION
Skip duplicate image urls in Oikotie export, cap to 100

- Bug in Drupal causes `ApartmentDocument.image_urls` to grow up to over a 1000 repetitive urls [link to bug in source](https://github.com/City-of-Helsinki/drupal-asuntotuotanto/blob/develop/public/modules/custom/asu_content/src/Plugin/ComputedField/ApartmentImages.php#L70-L103)