### PR TITLE
ASU-1890: Etuovi images fix

### DIFF
--- a/connections/etuovi/etuovi_mapper.py
+++ b/connections/etuovi/etuovi_mapper.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta
 from decimal import Decimal
-from typing import List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 from django.conf import settings
 from django.utils.html import strip_tags
@@ -31,7 +31,7 @@ from connections.etuovi.field_mapper import (
     REALTY_TYPE_MAPPING,
     TRADE_TYPE_MAPPING,
 )
-from connections.utils import convert_price_from_cents_to_eur
+from connections.utils import convert_price_from_cents_to_eur, resolve_floor_max
 
 # Guard against duplicated ES image_urls (same cap as Oikotie export).
 ETUOVI_MAX_IMAGES = 100
@@ -532,10 +532,19 @@ def map_realty_options(elastic_apartment: ApartmentDocument) -> List[RealtyOptio
     return realty_options
 
 
-def map_apartment_to_item(elastic_apartment: ApartmentDocument) -> Item:
+def map_apartment_to_item(
+    elastic_apartment: ApartmentDocument,
+    project_floor_max_lookup: Optional[Dict[str, int]] = None,
+) -> Item:
     """
     Maps the ElasticSearch apartment to the Etuovi Item.
     """
+    project_floor_max = None
+    if project_floor_max_lookup:
+        project_uuid = getattr(elastic_apartment, "project_uuid", None)
+        if project_uuid:
+            project_floor_max = project_floor_max_lookup.get(str(project_uuid))
+
     is_haso = (
         elastic_apartment.project_ownership_type.lower() == OwnershipType.HASO.value
     )
@@ -560,7 +569,7 @@ def map_apartment_to_item(elastic_apartment: ApartmentDocument) -> Item:
         "debtfreeprice": map_price(elastic_apartment, debtfreeprice_key),
         "energyclass": map_energy_class(elastic_apartment),
         "extralink": map_extra_links(elastic_apartment),
-        "floors": getattr(elastic_apartment, "floor_max", None),
+        "floors": resolve_floor_max(elastic_apartment, project_floor_max),
         "holdingtype": map_holding_type(elastic_apartment),
         "image": map_images(elastic_apartment),
         "itemgroup": map_item_group(elastic_apartment),

--- a/connections/etuovi/etuovi_mapper.py
+++ b/connections/etuovi/etuovi_mapper.py
@@ -33,6 +33,9 @@ from connections.etuovi.field_mapper import (
 )
 from connections.utils import convert_price_from_cents_to_eur
 
+# Guard against duplicated ES image_urls (same cap as Oikotie export).
+ETUOVI_MAX_IMAGES = 100
+
 
 def handle_field_value(field: Union[str, AttrList, None]) -> str:
     """
@@ -433,19 +436,28 @@ def map_apartment_to_image_types(
 
 def map_images(elastic_apartment: ApartmentDocument) -> List[Image]:
     """
-    Handles the mapping of Image properties. If the input value is a list of image urls,
-    create an Image for each of the urls.
+    Map apartment images for Etuovi export.
+
+    Deduplicates URLs and caps output at ETUOVI_MAX_IMAGES. The first occurrence
+    of each URL keeps its RealtyImageType.
     """
     image_type_mapping = map_apartment_to_image_types(elastic_apartment)
 
-    images = []
+    seen_urls: set[str] = set()
+    images: List[Image] = []
     image_seq = 1
     for image_type, field_value in image_type_mapping:
         for image_url in handle_field_value(field_value):
-            if image_url:
-                image = get_image_mapping(image_type, str(image_seq), image_url)
-                images.append(image)
-                image_seq += 1
+            if not image_url:
+                continue
+            url = str(image_url)
+            if url in seen_urls:
+                continue
+            seen_urls.add(url)
+            images.append(get_image_mapping(image_type, str(image_seq), url))
+            image_seq += 1
+            if len(images) >= ETUOVI_MAX_IMAGES:
+                return images
     return images
 
 

--- a/connections/etuovi/etuovi_mapper.py
+++ b/connections/etuovi/etuovi_mapper.py
@@ -37,12 +37,12 @@ from connections.utils import convert_price_from_cents_to_eur
 ETUOVI_MAX_IMAGES = 100
 
 
-def handle_field_value(field: Union[str, AttrList, None]) -> str:
+def handle_field_value(field: Union[str, AttrList, list, None]):
     """
     A generator that returns each instance of a list if the given field
-    is of type AttrList. Otherwise returns the literal value.
+    is of type AttrList or list. Otherwise returns the literal value.
     """
-    if isinstance(field, AttrList):
+    if isinstance(field, (AttrList, list)):
         for f in field:
             yield f
     else:
@@ -434,12 +434,36 @@ def map_apartment_to_image_types(
     ]
 
 
+def _assign_main_image_seq_zero(images: List[Image], main_url: str) -> None:
+    """
+    Move the main image to the front and assign it image_seq 0.
+
+    Remaining images are renumbered from 1 upward in their relative order.
+    """
+    main_index = next(
+        (index for index, image in enumerate(images) if image.image_url == main_url),
+        None,
+    )
+    if main_index is None:
+        return
+
+    main_image = images.pop(main_index)
+    main_image.image_seq = "0"
+    main_image.image_transfer_id = "0"
+    images.insert(0, main_image)
+
+    for seq, image in enumerate(images[1:], start=1):
+        image.image_seq = str(seq)
+        image.image_transfer_id = str(seq)
+
+
 def map_images(elastic_apartment: ApartmentDocument) -> List[Image]:
     """
     Map apartment images for Etuovi export.
 
     Deduplicates URLs and caps output at ETUOVI_MAX_IMAGES. The first occurrence
-    of each URL keeps its RealtyImageType.
+    of each URL keeps its RealtyImageType. When project_main_image_url is set,
+    that image is exported first with image_seq 0.
     """
     image_type_mapping = map_apartment_to_image_types(elastic_apartment)
 
@@ -457,7 +481,14 @@ def map_images(elastic_apartment: ApartmentDocument) -> List[Image]:
             images.append(get_image_mapping(image_type, str(image_seq), url))
             image_seq += 1
             if len(images) >= ETUOVI_MAX_IMAGES:
-                return images
+                break
+        if len(images) >= ETUOVI_MAX_IMAGES:
+            break
+
+    main_image_url = getattr(elastic_apartment, "project_main_image_url", None)
+    if main_image_url:
+        _assign_main_image_seq_zero(images, str(main_image_url))
+
     return images
 
 

--- a/connections/etuovi/services.py
+++ b/connections/etuovi/services.py
@@ -8,7 +8,7 @@ from django_etuovi.etuovi import create_xml_file
 from apartment.elastic.queries import get_apartments
 from connections.enums import ApartmentStateOfSale
 from connections.etuovi.etuovi_mapper import map_apartment_to_item
-from connections.utils import map_document
+from connections.utils import build_project_floor_max_by_uuid, map_document
 
 _logger = logging.getLogger(__name__)
 
@@ -34,12 +34,18 @@ def fetch_apartments_for_sale(verbose: bool = False) -> list:
     """
     Fetch apartments for sale from elasticsearch and map them for Etuovi
     """
-    scan = get_apartments_for_etuovi()
+    scan = list(get_apartments_for_etuovi())
+    project_floor_max_lookup = build_project_floor_max_by_uuid(scan)
+
+    def map_item(apartment):
+        return map_apartment_to_item(
+            apartment, project_floor_max_lookup=project_floor_max_lookup
+        )
 
     items = []
 
     for hit in scan:
-        apartment = map_document(hit, map_apartment_to_item)
+        apartment = map_document(hit, map_item)
         if apartment:
             items.append(apartment)
 

--- a/connections/oikotie/oikotie_mapper.py
+++ b/connections/oikotie/oikotie_mapper.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import date, timedelta
-from typing import List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 from django.conf import settings
 from django.utils.translation import gettext_lazy as _
@@ -53,7 +53,11 @@ from connections.oikotie.field_mapper import (
     NEW_DEVELOPMENT_STATUS_MAPPING,
     SITE_MAPPING,
 )
-from connections.utils import convert_price_from_cents_to_eur
+from connections.utils import (
+    _coerce_floor_value,
+    convert_price_from_cents_to_eur,
+    resolve_floor_max,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -202,17 +206,20 @@ def map_application_url(elastic_apartment: ElasticApartment) -> str:
     return ensure_str(elastic_apartment.url) or ""
 
 
-def map_floor_location(elastic_apartment: ElasticApartment) -> Optional[FloorLocation]:
-    if getattr(elastic_apartment, "floor", None) and getattr(
-        elastic_apartment, "floor_max", None
-    ):
-        high = elastic_apartment.floor == elastic_apartment.floor_max
-        low = elastic_apartment.floor == 1
+def map_floor_location(
+    elastic_apartment: ElasticApartment,
+    project_floor_max: Optional[int] = None,
+) -> Optional[FloorLocation]:
+    floor = _coerce_floor_value(getattr(elastic_apartment, "floor", None))
+    resolved_floor_max = resolve_floor_max(elastic_apartment, project_floor_max)
+    if floor and resolved_floor_max:
+        high = floor == resolved_floor_max
+        low = floor == 1
         return FloorLocation(
             high=high,
             low=low,
-            number=elastic_apartment.floor,
-            count=elastic_apartment.floor_max,
+            number=floor,
+            count=resolved_floor_max,
             description="",
         )
     else:
@@ -459,10 +466,19 @@ def form_description(elastic_apartment: ElasticApartment) -> Optional[str]:
     return form_description_with_link(elastic_apartment)
 
 
-def map_oikotie_apartment(elastic_apartment: ElasticApartment) -> Apartment:
+def map_oikotie_apartment(
+    elastic_apartment: ElasticApartment,
+    project_floor_max_lookup: Optional[Dict[str, int]] = None,
+) -> Apartment:
     """
     Maps the ElasticSearch data to the Oikotie Apartment dataclass.
     """
+    project_floor_max = None
+    if project_floor_max_lookup:
+        project_uuid = getattr(elastic_apartment, "project_uuid", None)
+        if project_uuid:
+            project_floor_max = project_floor_max_lookup.get(str(project_uuid))
+
     heating_options = getattr(elastic_apartment, "project_heating_options", None)
     construction_materials = getattr(
         elastic_apartment, "project_construction_materials", None
@@ -496,7 +512,9 @@ def map_oikotie_apartment(elastic_apartment: ElasticApartment) -> Apartment:
         "virtual_presentation": ensure_str(
             getattr(elastic_apartment, "project_virtual_presentation_url", None)
         ),
-        "floor_location": map_floor_location(elastic_apartment),
+        "floor_location": map_floor_location(
+            elastic_apartment, project_floor_max=project_floor_max
+        ),
         "number_of_rooms": _to_int(getattr(elastic_apartment, "room_count", None)),
         "room_types": ensure_str(
             getattr(elastic_apartment, "apartment_structure", None)

--- a/connections/oikotie/services.py
+++ b/connections/oikotie/services.py
@@ -12,7 +12,7 @@ from connections.oikotie.oikotie_mapper import (
     map_oikotie_apartment,
     map_oikotie_housing_company,
 )
-from connections.utils import map_document
+from connections.utils import build_project_floor_max_by_uuid, map_document
 
 _logger = logging.getLogger(__name__)
 
@@ -37,12 +37,19 @@ def fetch_apartments_for_sale() -> Tuple[list, list]:
     """
     Fetch apartments for sale from elasticsearch and map them for Oikotie
     """
-    scan = get_apartments_for_oikotie()
+    scan = list(get_apartments_for_oikotie())
+    project_floor_max_lookup = build_project_floor_max_by_uuid(scan)
+
+    def map_apartment(apartment):
+        return map_oikotie_apartment(
+            apartment, project_floor_max_lookup=project_floor_max_lookup
+        )
+
     apartments = []
     housing_companies = []
 
     for hit in scan:
-        apartment = map_document(hit, map_oikotie_apartment)
+        apartment = map_document(hit, map_apartment)
         housing = map_document(hit, map_oikotie_housing_company)
 
         if not apartment:

--- a/connections/tests/conftest.py
+++ b/connections/tests/conftest.py
@@ -6,10 +6,7 @@ from pytest import fixture
 from rest_framework.test import APIClient
 
 import connections
-from apartment.tests.factories import (
-    add_to_store,
-    clear_apartment_store,
-)
+from apartment.tests.factories import add_to_store, clear_apartment_store
 from apartment.tests.utils import TestDrupalSearchClient
 from connections.enums import ApartmentStateOfSale
 from connections.tests.factories import ApartmentMinimalFactory

--- a/connections/tests/conftest.py
+++ b/connections/tests/conftest.py
@@ -8,7 +8,6 @@ from rest_framework.test import APIClient
 import connections
 from apartment.tests.factories import (
     add_to_store,
-    APARTMENT_STORE,
     clear_apartment_store,
 )
 from apartment.tests.utils import TestDrupalSearchClient
@@ -185,67 +184,3 @@ def invalid_data_elastic_apartments_for_sale(elastic_apartments):
     add_to_store(apartments)
 
     yield apartments
-
-
-@fixture(autouse=True)
-def mock_connections_apartment_search(monkeypatch):
-    from connections.enums import ApartmentStateOfSale
-    from connections.etuovi.etuovi_mapper import map_apartment_to_item
-    from connections.oikotie.oikotie_mapper import (
-        map_oikotie_apartment,
-        map_oikotie_housing_company,
-    )
-    from connections.utils import build_project_floor_max_by_uuid, map_document
-
-    def _etuovi_source():
-        return [
-            apt
-            for apt in APARTMENT_STORE
-            if apt._language == "fi"
-            and apt.apartment_state_of_sale == ApartmentStateOfSale.FOR_SALE
-            and apt.publish_on_etuovi is True
-        ]
-
-    def _oikotie_source():
-        return [
-            apt
-            for apt in APARTMENT_STORE
-            if apt._language == "fi"
-            and apt.apartment_state_of_sale == ApartmentStateOfSale.FOR_SALE
-            and apt.publish_on_oikotie is True
-        ]
-
-    def _etuovi_fetch_apartments_for_sale(verbose=False):
-        source = _etuovi_source()
-        project_floor_max_lookup = build_project_floor_max_by_uuid(source)
-
-        def map_item(apartment):
-            return map_apartment_to_item(
-                apartment, project_floor_max_lookup=project_floor_max_lookup
-            )
-
-        items = []
-        for hit in source:
-            apartment = map_document(hit, map_item)
-            if apartment:
-                items.append(apartment)
-        return items
-
-    def _oikotie_fetch_apartments_for_sale():
-        source = _oikotie_source()
-        project_floor_max_lookup = build_project_floor_max_by_uuid(source)
-
-        def map_apartment(apartment):
-            return map_oikotie_apartment(
-                apartment, project_floor_max_lookup=project_floor_max_lookup
-            )
-
-        apartments = []
-        housing_companies = []
-        for hit in source:
-            apartment = map_document(hit, map_apartment)
-            housing = map_document(hit, map_oikotie_housing_company)
-            if apartment and housing:
-                apartments.append(apartment)
-                housing_companies.append(housing)
-        return apartments, housing_companies

--- a/connections/tests/conftest.py
+++ b/connections/tests/conftest.py
@@ -195,7 +195,7 @@ def mock_connections_apartment_search(monkeypatch):
         map_oikotie_apartment,
         map_oikotie_housing_company,
     )
-    from connections.utils import map_document
+    from connections.utils import build_project_floor_max_by_uuid, map_document
 
     def _etuovi_source():
         return [
@@ -216,18 +216,34 @@ def mock_connections_apartment_search(monkeypatch):
         ]
 
     def _etuovi_fetch_apartments_for_sale(verbose=False):
+        source = _etuovi_source()
+        project_floor_max_lookup = build_project_floor_max_by_uuid(source)
+
+        def map_item(apartment):
+            return map_apartment_to_item(
+                apartment, project_floor_max_lookup=project_floor_max_lookup
+            )
+
         items = []
-        for hit in _etuovi_source():
-            apartment = map_document(hit, map_apartment_to_item)
+        for hit in source:
+            apartment = map_document(hit, map_item)
             if apartment:
                 items.append(apartment)
         return items
 
     def _oikotie_fetch_apartments_for_sale():
+        source = _oikotie_source()
+        project_floor_max_lookup = build_project_floor_max_by_uuid(source)
+
+        def map_apartment(apartment):
+            return map_oikotie_apartment(
+                apartment, project_floor_max_lookup=project_floor_max_lookup
+            )
+
         apartments = []
         housing_companies = []
-        for hit in _oikotie_source():
-            apartment = map_document(hit, map_oikotie_apartment)
+        for hit in source:
+            apartment = map_document(hit, map_apartment)
             housing = map_document(hit, map_oikotie_housing_company)
             if apartment and housing:
                 apartments.append(apartment)

--- a/connections/tests/test_common_connection_utils.py
+++ b/connections/tests/test_common_connection_utils.py
@@ -41,12 +41,8 @@ class TestFloorMaxResolution:
         - Computes the highest floor or floor_max per project_uuid.
         """
         project_uuid = "same-project-uuid"
-        apt1 = ApartmentMinimalFactory(
-            project_uuid=project_uuid, floor=2, floor_max=1
-        )
-        apt2 = ApartmentMinimalFactory(
-            project_uuid=project_uuid, floor=7, floor_max=6
-        )
+        apt1 = ApartmentMinimalFactory(project_uuid=project_uuid, floor=2, floor_max=1)
+        apt2 = ApartmentMinimalFactory(project_uuid=project_uuid, floor=7, floor_max=6)
         apt3 = ApartmentMinimalFactory(project_uuid="other", floor=1, floor_max=3)
         lookup = build_project_floor_max_by_uuid([apt1, apt2, apt3])
         assert lookup[project_uuid] == 7

--- a/connections/tests/test_common_connection_utils.py
+++ b/connections/tests/test_common_connection_utils.py
@@ -1,9 +1,53 @@
 from decimal import Decimal
 
-from connections.utils import convert_price_from_cents_to_eur
+from connections.tests.factories import ApartmentMinimalFactory
+from connections.utils import (
+    build_project_floor_max_by_uuid,
+    convert_price_from_cents_to_eur,
+    resolve_floor_max,
+)
 
 
 class TestCommonConnectionUtils:
     def test_convert_price_from_cents_to_eur(self):
         assert convert_price_from_cents_to_eur(10000) == Decimal("100.0")
         assert convert_price_from_cents_to_eur(12345.67) == Decimal("123.46")
+
+
+class TestFloorMaxResolution:
+    def test_resolve_floor_max_returns_none_when_no_values(self):
+        """
+        - Returns None when floor and floor_max are both missing.
+        """
+        apartment = ApartmentMinimalFactory(floor=None, floor_max=None)
+        assert resolve_floor_max(apartment) is None
+
+    def test_resolve_floor_max_uses_floor_when_floor_max_too_low(self):
+        """
+        - Uses apartment floor when it exceeds floor_max.
+        """
+        apartment = ApartmentMinimalFactory(floor=5, floor_max=1)
+        assert resolve_floor_max(apartment) == 5
+
+    def test_resolve_floor_max_uses_project_max_when_higher(self):
+        """
+        - Uses project-level maximum when it exceeds apartment floor_max.
+        """
+        apartment = ApartmentMinimalFactory(floor=3, floor_max=1)
+        assert resolve_floor_max(apartment, project_floor_max=8) == 8
+
+    def test_build_project_floor_max_by_uuid(self):
+        """
+        - Computes the highest floor or floor_max per project_uuid.
+        """
+        project_uuid = "same-project-uuid"
+        apt1 = ApartmentMinimalFactory(
+            project_uuid=project_uuid, floor=2, floor_max=1
+        )
+        apt2 = ApartmentMinimalFactory(
+            project_uuid=project_uuid, floor=7, floor_max=6
+        )
+        apt3 = ApartmentMinimalFactory(project_uuid="other", floor=1, floor_max=3)
+        lookup = build_project_floor_max_by_uuid([apt1, apt2, apt3])
+        assert lookup[project_uuid] == 7
+        assert lookup["other"] == 3

--- a/connections/tests/test_etuovi.py
+++ b/connections/tests/test_etuovi.py
@@ -99,6 +99,20 @@ class TestEtuoviMapper:
             return
         raise Exception("Missing project_building_type should have thrown a ValueError")
 
+    def test_map_apartment_to_item_resolves_floor_max(self):
+        """
+        - Uses project-level floor max when apartment floor_max is too low.
+        """
+        project_uuid = "proj-123"
+        apartment = ApartmentMinimalFactory(
+            project_uuid=project_uuid,
+            floor=5,
+            floor_max=1,
+        )
+        lookup = {project_uuid: 8}
+        item = map_apartment_to_item(apartment, project_floor_max_lookup=lookup)
+        assert item.floors == 8
+
 
 class TestEtuoviImagesInXml:
     """

--- a/connections/tests/test_etuovi.py
+++ b/connections/tests/test_etuovi.py
@@ -159,7 +159,42 @@ class TestEtuoviImagesInXml:
         assert len(images) == 1
         assert images[0].image_url == repeated_url
         assert images[0].image_realtyimagetype == RealtyImageType.GENERAL_IMAGE
-        assert images[0].image_seq == "1"
+        assert images[0].image_seq == "0"
+
+    def test_map_images_main_image_gets_seq_zero(self):
+        """
+        - Main image is listed first with image_seq 0 when project_main_image_url is set.
+        - Other images are renumbered from 1 upward.
+        """
+        main_url = "https://test.example.com/main.jpg"
+        elastic_apartment = ApartmentMinimalFactory(
+            project_main_image_url=main_url,
+            project_image_urls=[
+                "https://test.example.com/project-1.jpg",
+                "https://test.example.com/project-2.jpg",
+            ],
+            image_urls=["https://test.example.com/apartment-1.jpg"],
+            floor_plan_image="https://test.example.com/floorplan.jpg",
+        )
+        images = map_images(elastic_apartment)
+
+        assert images[0].image_url == main_url
+        assert images[0].image_realtyimagetype == RealtyImageType.MAIN_IMAGE
+        assert [image.image_seq for image in images] == ["0", "1", "2", "3", "4"]
+
+    def test_map_images_without_main_image_starts_seq_at_one(self):
+        """
+        - When project_main_image_url is missing, image_seq starts at 1.
+        """
+        elastic_apartment = ApartmentMinimalFactory(
+            project_main_image_url=None,
+            project_image_urls=["https://test.example.com/project-1.jpg"],
+            image_urls=["https://test.example.com/apartment-1.jpg"],
+            floor_plan_image=None,
+        )
+        images = map_images(elastic_apartment)
+
+        assert [image.image_seq for image in images] == ["1", "2"]
 
     def test_map_images_caps_at_export_max(self):
         """

--- a/connections/tests/test_etuovi.py
+++ b/connections/tests/test_etuovi.py
@@ -5,11 +5,12 @@ from uuid import UUID
 import pytest
 from django.conf import settings
 from django.core.management import call_command
+from django_etuovi.enums import RealtyImageType
 from django_etuovi.utils.testing import check_dataclass_typing
 
 from apartment.enums import OwnershipType
 from apartment.tests.factories import ApartmentDocumentFactory
-from connections.etuovi.etuovi_mapper import map_apartment_to_item
+from connections.etuovi.etuovi_mapper import map_apartment_to_item, map_images
 from connections.etuovi.services import create_xml, fetch_apartments_for_sale
 from connections.models import MappedApartment
 from connections.tests.factories import ApartmentMinimalFactory
@@ -140,6 +141,45 @@ class TestEtuoviImagesInXml:
         all_expected_urls = project_image_urls + image_urls + [floor_plan_image]
         for url in all_expected_urls:
             assert url in xml_content, f"URL {url} not found in Etuovi XML"
+
+    def test_map_images_deduplicates_repeated_urls(self):
+        """
+        - Duplicate image_urls from ES are mapped once.
+        - First occurrence keeps its RealtyImageType.
+        """
+        repeated_url = "https://test.example.com/repeated.jpg"
+        elastic_apartment = ApartmentMinimalFactory(
+            project_main_image_url=repeated_url,
+            project_image_urls=[repeated_url] * 300,
+            image_urls=[repeated_url] * 300,
+            floor_plan_image=None,
+        )
+        images = map_images(elastic_apartment)
+
+        assert len(images) == 1
+        assert images[0].image_url == repeated_url
+        assert images[0].image_realtyimagetype == RealtyImageType.GENERAL_IMAGE
+        assert images[0].image_seq == "1"
+
+    def test_map_images_caps_at_export_max(self):
+        """
+        - Protects Etuovi XML from oversized image lists in ES.
+        """
+        unique_urls = [
+            f"https://test.example.com/image-{index}.jpg" for index in range(101)
+        ]
+        elastic_apartment = ApartmentMinimalFactory(
+            project_main_image_url=None,
+            project_image_urls=[],
+            image_urls=unique_urls,
+            floor_plan_image=None,
+        )
+        images = map_images(elastic_apartment)
+
+        assert len(images) == 100
+        assert images[0].image_url == "https://test.example.com/image-0.jpg"
+        assert images[99].image_url == "https://test.example.com/image-99.jpg"
+        assert [image.image_seq for image in images] == [str(seq) for seq in range(1, 101)]
 
 
 @pytest.mark.usefixtures("client")

--- a/connections/tests/test_etuovi.py
+++ b/connections/tests/test_etuovi.py
@@ -163,7 +163,8 @@ class TestEtuoviImagesInXml:
 
     def test_map_images_main_image_gets_seq_zero(self):
         """
-        - Main image is listed first with image_seq 0 when project_main_image_url is set.
+        - Main image is listed first with image_seq 0 when
+          project_main_image_url is set.
         - Other images are renumbered from 1 upward.
         """
         main_url = "https://test.example.com/main.jpg"
@@ -214,7 +215,8 @@ class TestEtuoviImagesInXml:
         assert len(images) == 100
         assert images[0].image_url == "https://test.example.com/image-0.jpg"
         assert images[99].image_url == "https://test.example.com/image-99.jpg"
-        assert [image.image_seq for image in images] == [str(seq) for seq in range(1, 101)]
+        expected_seq = [str(seq) for seq in range(1, 101)]
+        assert [image.image_seq for image in images] == expected_seq
 
 
 @pytest.mark.usefixtures("client")

--- a/connections/tests/test_oikotie.py
+++ b/connections/tests/test_oikotie.py
@@ -107,6 +107,26 @@ class TestOikotieMapper:
         oikotie_floor_location = map_floor_location(elastic_apartment)
         check_dataclass_typing(oikotie_floor_location)
 
+    def test_map_floor_location_resolves_floor_max(self):
+        """
+        - Uses project-level floor max when apartment floor_max is too low.
+        - high is computed against the resolved floor_max.
+        """
+        apartment = ApartmentMinimalFactory(floor=5, floor_max=1)
+        location = map_floor_location(apartment, project_floor_max=8)
+        assert location.count == 8
+        assert location.number == 5
+        assert location.high is False
+
+    def test_map_floor_location_marks_top_floor_using_resolved_max(self):
+        """
+        - Marks top floor when apartment floor equals resolved floor_max.
+        """
+        apartment = ApartmentMinimalFactory(floor=8, floor_max=1)
+        location = map_floor_location(apartment, project_floor_max=8)
+        assert location.count == 8
+        assert location.high is True
+
     def test_elastic_to_oikotie__housing_company_apartment__mapping_types(self):
         elastic_apartment = ApartmentDocumentFactory()
         oikotie_housing_company_apartment = map_apartment(elastic_apartment)

--- a/connections/utils.py
+++ b/connections/utils.py
@@ -1,8 +1,8 @@
 import logging
 import re
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from decimal import Decimal, ROUND_HALF_UP
-from typing import List, Union
+from typing import Dict, List, Optional, Union
 
 from django.utils.html import strip_tags
 from lxml import etree
@@ -124,3 +124,77 @@ def validate_apartment_required_fields(
         if not getattr(apartment, field_name, None):
             missing_fields.append(field_name)
     return missing_fields
+
+
+def _coerce_floor_value(value) -> Optional[int]:
+    """Coerce floor or floor_max to int; return None if invalid or empty."""
+    if value is None:
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    try:
+        stripped = str(value).strip()
+        return int(float(stripped)) if stripped else None
+    except (ValueError, TypeError):
+        return None
+
+
+def build_project_floor_max_by_uuid(
+    apartments: Iterable["ApartmentDocument"],  # noqa: F821
+) -> Dict[str, int]:
+    """
+    Build a lookup of the highest floor-related value per project.
+
+    For each project, considers both floor_max and floor from every apartment
+    so export mappers can correct erroneous per-apartment floor_max values.
+    """
+    project_floor_max: Dict[str, int] = {}
+    for apartment in apartments:
+        project_uuid = getattr(apartment, "project_uuid", None)
+        if not project_uuid:
+            continue
+
+        candidates: List[int] = []
+        floor_max = _coerce_floor_value(getattr(apartment, "floor_max", None))
+        floor = _coerce_floor_value(getattr(apartment, "floor", None))
+        if floor_max is not None:
+            candidates.append(floor_max)
+        if floor is not None:
+            candidates.append(floor)
+        if not candidates:
+            continue
+
+        project_key = str(project_uuid)
+        apartment_max = max(candidates)
+        current_max = project_floor_max.get(project_key)
+        if current_max is None or apartment_max > current_max:
+            project_floor_max[project_key] = apartment_max
+
+    return project_floor_max
+
+
+def resolve_floor_max(
+    apartment: "ApartmentDocument",  # noqa: F821
+    project_floor_max: Optional[int] = None,
+) -> Optional[int]:
+    """
+    Return floor_max corrected against apartment floor and project maximum.
+
+    Guards against floor_max being lower than the apartment floor or the
+    highest floor-related value seen elsewhere in the same project.
+    """
+    candidates: List[int] = []
+    floor_max = _coerce_floor_value(getattr(apartment, "floor_max", None))
+    floor = _coerce_floor_value(getattr(apartment, "floor", None))
+    if floor_max is not None:
+        candidates.append(floor_max)
+    if floor is not None:
+        candidates.append(floor)
+    if project_floor_max is not None:
+        candidates.append(int(project_floor_max))
+
+    if not candidates:
+        return None
+    return max(candidates)


### PR DESCRIPTION
* Make sure project_main_image_url is set as first image on Etuovi export
* Fix Etuovi XML featuring duplicate images
    * See City-of-Helsinki/apartment-application-service/pull/600 for more info on Drupal bug that causes this
* Correct floor_max in Etuovi/Oikotie exports using per-project max floor values    
    * Resolve building floor count from the highest floor/floor_max across apartments in the same project, so erroneous low floor_max values do not leak into export XML
    * e.g. `ApartmentDocument.floor` is `5` but `ApartmentDocument.floor_max` is `1` then set the floor count to `5` in the export
