### PR TITLE
ASU-1888: fix apartment counters

### DIFF
--- a/apartment/elastic/queries.py
+++ b/apartment/elastic/queries.py
@@ -317,14 +317,11 @@ def get_project_apartment_sale_state_counts(
     if not apartment_uuid_to_project_uuid:
         return counts
 
-    # "Winning" here means the first reservation in the list for an apartment.
-    # Queue positions are not always present (e.g. in some state transitions and
-    # in tests), but list_position is always set.
     winning_reservations = (
         ApartmentReservation.objects.active()
         .filter(
             apartment_uuid__in=list(apartment_uuid_to_project_uuid.keys()),
-            list_position=1,
+            queue_position=1,
         )
         .values_list("apartment_uuid", "state")
     )

--- a/apartment/tests/test_queries.py
+++ b/apartment/tests/test_queries.py
@@ -112,7 +112,7 @@ def test_sale_state_counts_categorizes_by_winning_reservation_state(
     elasticsearch,
 ):
     """
-    Verify that the winning reservation (list_position=1) drives categorization.
+    Verify that the winning reservation (queue_position=1) drives categorization.
 
     - SOLD state -> sold_apartment_count.
     - RESERVED state -> reserved_apartment_count.
@@ -130,16 +130,19 @@ def test_sale_state_counts_categorizes_by_winning_reservation_state(
         apartment_uuid=sold_apt.uuid,
         state=ApartmentReservationState.SOLD,
         list_position=1,
+        queue_position=1,
     )
     ApartmentReservationFactory(
         apartment_uuid=reserved_apt.uuid,
         state=ApartmentReservationState.RESERVED,
         list_position=1,
+        queue_position=1,
     )
     ApartmentReservationFactory(
         apartment_uuid=submitted_apt.uuid,
         state=ApartmentReservationState.SUBMITTED,
         list_position=1,
+        queue_position=1,
     )
 
     result = get_project_apartment_sale_state_counts([str(first.project_uuid)])
@@ -152,14 +155,14 @@ def test_sale_state_counts_categorizes_by_winning_reservation_state(
 
 
 @pytest.mark.django_db
-def test_sale_state_counts_only_counts_list_position_one(
+def test_sale_state_counts_only_counts_queue_position_one(
     elasticsearch,
 ):
     """
-    Verify that only the winning (list_position=1) reservation is considered.
+    Verify that only the winning (queue_position=1) reservation is considered.
 
-    - A later list_position=2 reservation must not influence the count.
-    - With list_position=1 RESERVED and list_position=2 OFFERED the apartment
+    - A later queue_position=2 reservation must not influence the count.
+    - With queue_position=1 RESERVED and queue_position=2 OFFERED the apartment
       is counted as reserved.
     """
     first = ApartmentDocumentFactory()
@@ -169,11 +172,13 @@ def test_sale_state_counts_only_counts_list_position_one(
         apartment_uuid=first.uuid,
         state=ApartmentReservationState.RESERVED,
         list_position=1,
+        queue_position=1,
     )
     ApartmentReservationFactory(
         apartment_uuid=first.uuid,
         state=ApartmentReservationState.OFFERED,
         list_position=2,
+        queue_position=2,
     )
 
     result = get_project_apartment_sale_state_counts([str(first.project_uuid)])
@@ -181,6 +186,41 @@ def test_sale_state_counts_only_counts_list_position_one(
     assert result[str(first.project_uuid)] == {
         "sold_apartment_count": 0,
         "reserved_apartment_count": 1,
+        "free_apartment_count": 0,
+    }
+
+
+@pytest.mark.django_db
+def test_sale_state_counts_uses_queue_position_when_list_position_diverges(
+    elasticsearch,
+):
+    """
+    Verify sold apartments are counted when queue_position=1 but list_position>1.
+
+    - Canceled reservations keep their list_position but lose queue_position.
+    - The buyer at queue_position=1 must be counted as sold, not free.
+    """
+    first = ApartmentDocumentFactory()
+    add_to_store([first])
+
+    ApartmentReservationFactory(
+        apartment_uuid=first.uuid,
+        state=ApartmentReservationState.CANCELED,
+        list_position=1,
+        queue_position=None,
+    )
+    ApartmentReservationFactory(
+        apartment_uuid=first.uuid,
+        state=ApartmentReservationState.SOLD,
+        list_position=7,
+        queue_position=1,
+    )
+
+    result = get_project_apartment_sale_state_counts([str(first.project_uuid)])
+
+    assert result[str(first.project_uuid)] == {
+        "sold_apartment_count": 1,
+        "reserved_apartment_count": 0,
         "free_apartment_count": 0,
     }
 
@@ -202,6 +242,7 @@ def test_sale_state_counts_excludes_canceled_reservations(
         apartment_uuid=first.uuid,
         state=ApartmentReservationState.CANCELED,
         list_position=1,
+        queue_position=None,
     )
 
     result = get_project_apartment_sale_state_counts([str(first.project_uuid)])
@@ -231,11 +272,13 @@ def test_sale_state_counts_keeps_projects_independent(
         apartment_uuid=project_a_apt.uuid,
         state=ApartmentReservationState.SOLD,
         list_position=1,
+        queue_position=1,
     )
     ApartmentReservationFactory(
         apartment_uuid=project_b_apt.uuid,
         state=ApartmentReservationState.RESERVED,
         list_position=1,
+        queue_position=1,
     )
 
     result = get_project_apartment_sale_state_counts(

--- a/application_form/services/application.py
+++ b/application_form/services/application.py
@@ -3,6 +3,7 @@ import uuid
 from datetime import date
 from typing import Iterable, List, Optional, Union
 
+import sentry_sdk
 from django.contrib.auth import get_user_model
 from django.core.mail import EmailMessage
 from django.db import transaction
@@ -57,6 +58,44 @@ def _apartment_has_locked_winner(apartment_uuid: uuid.UUID) -> bool:
         apartment_uuid=apartment_uuid,
         state__in=LOCKED_RESERVATION_STATES,
     ).exists()
+
+
+def _report_late_application_to_sold_apartments(
+    apartment_uuids: Iterable[uuid.UUID],
+    application_external_uuid: uuid.UUID,
+) -> None:
+    """
+    Notify Sentry when a late application targets an apartment that is sold.
+
+    Parameters:
+        apartment_uuids (Iterable[uuid.UUID]): Apartments included in the application.
+        application_external_uuid (uuid.UUID): Drupal application identifier.
+    """
+    sold_apartment_uuids = [
+        str(apt_uuid)
+        for apt_uuid in apartment_uuids
+        if _apartment_has_locked_winner(apt_uuid)
+    ]
+    if not sold_apartment_uuids:
+        return
+
+    _logger.warning(
+        "Late application %s submitted to sold apartment(s): %s",
+        application_external_uuid,
+        ", ".join(sold_apartment_uuids),
+    )
+    with sentry_sdk.push_scope() as scope:
+        scope.set_context(
+            "late_application_to_sold_apartment",
+            {
+                "application_external_uuid": str(application_external_uuid),
+                "sold_apartment_uuids": sold_apartment_uuids,
+            },
+        )
+        sentry_sdk.capture_message(
+            "Late application submitted to sold apartment",
+            level="warning",
+        )
 
 
 @transaction.atomic
@@ -178,10 +217,13 @@ def create_application(
             application=application,
         )
     apartment_data = data.pop("apartments")
+    apartment_uuids = []
     for apartment_item in apartment_data:
+        apartment_uuid = apartment_item["identifier"]
+        apartment_uuids.append(apartment_uuid)
         ApplicationApartment.objects.create(
             application=application,
-            apartment_uuid=apartment_item["identifier"],
+            apartment_uuid=apartment_uuid,
             priority_number=apartment_item["priority"],
         )
 
@@ -190,6 +232,12 @@ def create_application(
     )
 
     add_application_to_queues(application, user=user)
+
+    if submitted_late:
+        _report_late_application_to_sold_apartments(
+            apartment_uuids,
+            application.external_uuid,
+        )
 
     return application
 

--- a/application_form/tests/test_late_application_sold_sentry.py
+++ b/application_form/tests/test_late_application_sold_sentry.py
@@ -1,0 +1,153 @@
+from unittest.mock import patch
+
+import pytest
+
+from application_form.enums import ApartmentReservationState, ApplicationType
+from application_form.services.application import create_application
+from application_form.tests.conftest import (
+    create_validated_application_data,
+    prepare_metadata,
+)
+from application_form.tests.factories import ApartmentReservationFactory
+from users.tests.factories import ProfileFactory
+
+
+@pytest.mark.django_db
+@patch("application_form.services.application.sentry_sdk.capture_message")
+def test_late_application_to_sold_apartment_reports_to_sentry(
+    mock_capture_message,
+    elastic_single_project_with_apartments,
+):
+    """
+    A late application targeting a sold apartment must notify Sentry.
+
+    - Uses the existing sold-reservation check (`_apartment_has_locked_winner`).
+    - Application creation must still succeed; this is observability only.
+    """
+    apartments = elastic_single_project_with_apartments
+    sold_apartment = apartments[0]
+
+    ApartmentReservationFactory(
+        apartment_uuid=sold_apartment.uuid,
+        state=ApartmentReservationState.SOLD,
+        list_position=1,
+        queue_position=1,
+    )
+
+    profile = ProfileFactory()
+    data = create_validated_application_data(
+        profile, ApplicationType.HASO, num_applicants=1
+    )
+    data["apartments"] = [{"priority": 0, "identifier": sold_apartment.uuid}]
+    data = prepare_metadata(data, profile)
+
+    application = create_application(data, submitted_late=True)
+
+    mock_capture_message.assert_called_once_with(
+        "Late application submitted to sold apartment",
+        level="warning",
+    )
+    assert application.submitted_late is True
+
+
+@pytest.mark.django_db
+@patch("application_form.services.application.sentry_sdk.capture_message")
+def test_late_application_to_unsold_apartment_does_not_report_to_sentry(
+    mock_capture_message,
+    elastic_single_project_with_apartments,
+):
+    """
+    Late applications to apartments without a sold reservation must stay silent.
+
+    - No Sentry message when the apartment queue has no sold winner.
+    """
+    apartments = elastic_single_project_with_apartments
+    free_apartment = apartments[1]
+
+    profile = ProfileFactory()
+    data = create_validated_application_data(
+        profile, ApplicationType.HASO, num_applicants=1
+    )
+    data["apartments"] = [{"priority": 0, "identifier": free_apartment.uuid}]
+    data = prepare_metadata(data, profile)
+
+    create_application(data, submitted_late=True)
+
+    mock_capture_message.assert_not_called()
+
+
+@pytest.mark.django_db
+@patch("application_form.services.application.sentry_sdk.capture_message")
+def test_on_time_application_to_sold_apartment_does_not_report_to_sentry(
+    mock_capture_message,
+    elastic_single_project_with_apartments,
+):
+    """
+    On-time applications must not trigger the sold-apartment Sentry alert.
+
+    - Only late (`submitted_late=True`) submissions are in scope.
+    """
+    apartments = elastic_single_project_with_apartments
+    sold_apartment = apartments[0]
+
+    ApartmentReservationFactory(
+        apartment_uuid=sold_apartment.uuid,
+        state=ApartmentReservationState.SOLD,
+        list_position=1,
+        queue_position=1,
+    )
+
+    profile = ProfileFactory()
+    data = create_validated_application_data(
+        profile, ApplicationType.HASO, num_applicants=1
+    )
+    data["apartments"] = [{"priority": 0, "identifier": sold_apartment.uuid}]
+    data = prepare_metadata(data, profile)
+
+    create_application(data, submitted_late=False)
+
+    mock_capture_message.assert_not_called()
+
+
+@pytest.mark.django_db
+@patch("application_form.services.application.sentry_sdk.capture_message")
+def test_late_application_to_sold_apartment_includes_context_in_sentry_scope(
+    mock_capture_message,
+    elastic_single_project_with_apartments,
+):
+    """
+    Sentry context must identify the application and sold apartment UUIDs.
+
+    - Context is attached inside a isolated scope before capture_message.
+    """
+    apartments = elastic_single_project_with_apartments
+    sold_apartment = apartments[0]
+
+    ApartmentReservationFactory(
+        apartment_uuid=sold_apartment.uuid,
+        state=ApartmentReservationState.SOLD,
+        list_position=1,
+        queue_position=1,
+    )
+
+    profile = ProfileFactory()
+    data = create_validated_application_data(
+        profile, ApplicationType.HASO, num_applicants=1
+    )
+    data["apartments"] = [{"priority": 0, "identifier": sold_apartment.uuid}]
+    data = prepare_metadata(data, profile)
+
+    with patch(
+        "application_form.services.application.sentry_sdk.push_scope"
+    ) as mock_push_scope:
+        scope = mock_push_scope.return_value.__enter__.return_value
+        create_application(data, submitted_late=True)
+
+    scope.set_context.assert_called_once_with(
+        "late_application_to_sold_apartment",
+        {
+            "application_external_uuid": str(data["external_uuid"]),
+            "sold_apartment_uuids": [str(sold_apartment.uuid)],
+        },
+    )
+    mock_capture_message.assert_called_once()


### PR DESCRIPTION
- **Fix calculation error in `get_project_apartment_sale_state_counts`**
- **Add Sentry warning if a sold apartment receives a late-submitted application**
